### PR TITLE
Multiple Culture Support, Extended two indicators

### DIFF
--- a/Trady.Analysis/Indicator/CandlesExtension.cs
+++ b/Trady.Analysis/Indicator/CandlesExtension.cs
@@ -36,8 +36,14 @@ namespace Trady.Analysis.Indicator
         public static IList<decimal?> ClosePriceChange(this IList<Candle> candles, int? startIndex = null, int? endIndex = null)
             => new ClosePriceChange(candles).Compute(startIndex, endIndex);
 
+        public static IList<decimal?> ClosePriceChange(this IList<Candle> candles, int numberOfDays, int? startIndex = null, int? endIndex = null)
+            => new ClosePriceChange(candles, numberOfDays).Compute(startIndex, endIndex);
+
         public static IList<decimal?> ClosePricePercentageChange(this IList<Candle> candles, int? startIndex = null, int? endIndex = null)
             => new ClosePricePercentageChange(candles).Compute(startIndex, endIndex);
+
+        public static IList<decimal?> ClosePricePercentageChange(this IList<Candle> candles, int numberOfDays, int? startIndex = null, int? endIndex = null)
+            => new ClosePricePercentageChange(candles, numberOfDays).Compute(startIndex, endIndex);
 
         public static IList<decimal?> Dmi(this IList<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new DirectionalMovementIndex(candles, periodCount).Compute(startIndex, endIndex);

--- a/Trady.Analysis/Indicator/ClosePriceChange.cs
+++ b/Trady.Analysis/Indicator/ClosePriceChange.cs
@@ -7,16 +7,19 @@ namespace Trady.Analysis.Indicator
 {
     public partial class ClosePriceChange : AnalyzableBase<decimal, decimal?>
     {
-        public ClosePriceChange(IList<Candle> candles)
-            : this(candles.Select(c => c.Close).ToList())
+        public int NumberOfDays { get; }
+
+        public ClosePriceChange(IList<Candle> candles, int numberOfDays = 1)
+            : this(candles.Select(c => c.Close).ToList(), numberOfDays)
         {
         }
 
-        public ClosePriceChange(IList<decimal> closes) : base(closes)
+        public ClosePriceChange(IList<decimal> closes, int numberOfDays = 1) : base(closes)
         {
+            NumberOfDays = numberOfDays;
         }
 
         protected override decimal? ComputeByIndexImpl(int index)
-           => index > 0 ? Inputs[index] - Inputs[index - 1] : (decimal?)null;
+           => index >= NumberOfDays ? Inputs[index] - Inputs[index - NumberOfDays] : (decimal?)null;
     }
 }

--- a/Trady.Analysis/Indicator/ClosePricePercentageChange.cs
+++ b/Trady.Analysis/Indicator/ClosePricePercentageChange.cs
@@ -7,16 +7,20 @@ namespace Trady.Analysis.Indicator
 {
     public partial class ClosePricePercentageChange : AnalyzableBase<decimal, decimal?>
     {
-        public ClosePricePercentageChange(IList<Candle> candles)
-            : this(candles.Select(c => c.Close).ToList())
+        public int NumberOfDays { get; } 
+
+
+        public ClosePricePercentageChange(IList<Candle> candles, int numberOfDays = 1)
+            : this(candles.Select(c => c.Close).ToList(), numberOfDays)
         {
         }
 
-        public ClosePricePercentageChange(IList<decimal> closes) : base(closes)
+        public ClosePricePercentageChange(IList<decimal> closes, int numberOfDays = 1) : base(closes)
         {
+            NumberOfDays = numberOfDays;
         }
 
         protected override decimal? ComputeByIndexImpl(int index)
-           => index > 0 ? (Inputs[index] - Inputs[index - 1]) / Inputs[index - 1] * 100 : (decimal?)null;
+           => index >= NumberOfDays ? (Inputs[index] - Inputs[index - NumberOfDays]) / Inputs[index - NumberOfDays] * 100 : (decimal?)null;
     }
 }

--- a/Trady.Importer/CsvImporter.cs
+++ b/Trady.Importer/CsvImporter.cs
@@ -1,10 +1,12 @@
 ﻿using CsvHelper;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using CsvHelper.Configuration;
 using Trady.Core;
 using Trady.Core.Period;
 using Trady.Importer.Helper;
@@ -14,10 +16,17 @@ namespace Trady.Importer
     public class CsvImporter : IImporter
     {
         private string _path;
+        private readonly CultureInfo _culture;
 
-        public CsvImporter(string path)
+        public CsvImporter(string path) : this(path, CultureInfo.CurrentCulture)
+        {
+
+        }
+
+        public CsvImporter(string path, CultureInfo culture)
         {
             _path = path;
+            _culture = culture;
         }
 
         public async Task<IList<Candle>> ImportAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, PeriodOption period = PeriodOption.Daily, CancellationToken token = default(CancellationToken))
@@ -26,20 +35,32 @@ namespace Trady.Importer
             {
                 using (var fs = File.OpenRead(_path))
                 using (var sr = new StreamReader(fs))
-                using (var csvReader = new CsvReader(sr))
+                using (var csvReader = new CsvReader(sr, new CsvConfiguration() { CultureInfo = _culture }))
                 {
                     var candles = new List<Candle>();
                     while (csvReader.Read())
                     {
-                        var record = csvReader.CurrentRecord;
-                        var recordDatetime = Convert.ToDateTime(record[0]);
-                        if (startTime.HasValue && recordDatetime < startTime.Value || endTime.HasValue && recordDatetime >= endTime.Value)
-                            continue;
-                        candles.Add(record.CreateCandle());
+                        var date = csvReader.GetField<DateTime>(0);
+                        if ((!startTime.HasValue || date >= startTime) && (!endTime.HasValue || date <= endTime))
+                            candles.Add(this.GetRecord(csvReader));
                     }
                     return candles.OrderBy(c => c.DateTime).ToList();
                 }
             });
         }
+
+        public Candle GetRecord(CsvReader csv)
+        {
+            // By using GetField Methodo of the CSV Reader Culture Info set in the configuration is used
+            return new Candle(
+                csv.GetField<DateTime>(0),
+                csv.GetField<Decimal>(1),
+                csv.GetField<Decimal>(2),
+                csv.GetField<Decimal>(3),
+                csv.GetField<Decimal>(4),
+                csv.GetField<Decimal>(5)
+            );
+        }
+
     }
 }

--- a/Trady.Test/ImporterTest.cs
+++ b/Trady.Test/ImporterTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Trady.Importer;
 using System.Linq;
@@ -46,5 +47,15 @@ namespace Trady.Test
 			Assert.AreEqual(candle.Close, 2257.83m);
 			Assert.AreEqual(candle.Volume, 644_640_832);
 		}
+
+        [TestMethod]
+        public void ImportFromCsv()
+        {
+            var importer = new CsvImporter("fb.csv", new CultureInfo("en-US"));
+            var candles = importer.ImportAsync("FB").Result;
+            Assert.AreEqual(candles.Count(), 1216);
+            var firstCandle = candles.First();
+            Assert.AreEqual(firstCandle.DateTime, new DateTime(2012,5,18));
+        }
     }
 }

--- a/Trady.Test/IndicatorTest.cs
+++ b/Trady.Test/IndicatorTest.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Trady.Analysis.Indicator;
@@ -12,7 +13,7 @@ namespace Trady.Test
     {
         async Task<IList<Candle>> ImportCandlesAsync()
         {
-            var csvImporter = new Importer.CsvImporter("fb.csv");
+            var csvImporter = new Importer.CsvImporter("fb.csv", new CultureInfo("en-US"));
             return await csvImporter.ImportAsync("fb");
         }
 
@@ -110,6 +111,10 @@ namespace Trady.Test
             var indicator = new ClosePriceChange(candles);
             var result = indicator[candles.Count - 1];
             Assert.IsTrue(0.16m.IsApproximatelyEquals(result.Value));
+
+            indicator = new ClosePriceChange(candles, 20);
+            result = indicator[candles.Count - 1];
+            Assert.IsTrue(6.41m.IsApproximatelyEquals(result.Value));
         }
 
         [TestMethod]
@@ -119,6 +124,11 @@ namespace Trady.Test
             var indicator = new ClosePricePercentageChange(candles);
             var result = indicator[candles.Count - 1];
             Assert.IsTrue(0.1145m.IsApproximatelyEquals(result.Value));
+
+            indicator = new ClosePricePercentageChange(candles, 20);
+            result = indicator[candles.Count - 1];
+            Assert.IsTrue(4.800m.IsApproximatelyEquals(result.Value));
+
         }
 
         [TestMethod]

--- a/Trady.Test/MiscTest.cs
+++ b/Trady.Test/MiscTest.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Trady.Core;
@@ -16,7 +17,7 @@ namespace Trady.Test
     {
         public async Task<IList<Candle>> ImportCandlesAsync()
         {
-            var csvImporter = new Importer.CsvImporter("fb.csv");
+            var csvImporter = new Importer.CsvImporter("fb.csv", new CultureInfo("en-US"));
             return await csvImporter.ImportAsync("fb");
         }
 


### PR DESCRIPTION
Hi, first of all, great job on this amazing library!
I did some extensions and some little improvements that might be nice to have directly on your code and not in my branch, so others get this.

Add Culture to CSV Importer to avoid failing when running on machines with different cultures.

Extend Indicators ClosePricePercentageChange and ClosePriceChange to support indicators for different number of days
Add both indicators extensions to the CandlesExtension class. I added another method for each option so users of the other already existent option doesn't need to change parameters.
Added tests for everything

If you want to discuss more you can find me through skype @fernandoaramburu.
Hope this help.