### PR TITLE
Candle abstraction

### DIFF
--- a/Trady.Analysis/AnalyzableTick.cs
+++ b/Trady.Analysis/AnalyzableTick.cs
@@ -6,6 +6,7 @@ namespace Trady.Analysis
     public class AnalyzableTick<T> : IAnalyzableTick<T>
     {
         public DateTime? DateTime { get; }
+
         public T Tick { get; }
 
         object IAnalyzableTick.Tick => Tick;

--- a/Trady.Analysis/AnalyzeContext.cs
+++ b/Trady.Analysis/AnalyzeContext.cs
@@ -76,9 +76,9 @@ namespace Trady.Analysis
         #endregion
     }
 
-    public class AnalyzeContext : AnalyzeContext<Candle>
+    public class AnalyzeContext : AnalyzeContext<IOhlcvData>
     {
-        public AnalyzeContext(IEnumerable<Candle> backingList) : base(backingList)
+        public AnalyzeContext(IEnumerable<IOhlcvData> backingList) : base(backingList)
         {
         }
 

--- a/Trady.Analysis/AnalyzeContext.cs
+++ b/Trady.Analysis/AnalyzeContext.cs
@@ -82,7 +82,7 @@ namespace Trady.Analysis
         {
         }
 
-        public Predicate<IndexedCandle> GetRule(string name, params decimal[] parameters)
-            => GetRule<IndexedCandle>(name, parameters);
+        public Predicate<IIndexedOhlcvData> GetRule(string name, params decimal[] parameters)
+            => GetRule<IIndexedOhlcvData>(name, parameters);
     }
 }

--- a/Trady.Analysis/Backtest/Builder.cs
+++ b/Trady.Analysis/Backtest/Builder.cs
@@ -8,7 +8,7 @@ namespace Trady.Analysis.Backtest
     public class Builder
     {
         private IDictionary<IEnumerable<IOhlcvData>, int> _weightings;
-        private Predicate<IndexedCandle> _buyRule, _sellRule;
+        private Predicate<IIndexedOhlcvData> _buyRule, _sellRule;
 
         public Builder() : this(null, null, null)
         {
@@ -16,8 +16,8 @@ namespace Trady.Analysis.Backtest
 
         private Builder(
             IDictionary<IEnumerable<IOhlcvData>, int> weightings, 
-            Predicate<IndexedCandle> buyRule, 
-            Predicate<IndexedCandle> sellRule)
+            Predicate<IIndexedOhlcvData> buyRule, 
+            Predicate<IIndexedOhlcvData> sellRule)
         {
             _weightings = weightings ?? new Dictionary<IEnumerable<IOhlcvData>, int>();
             _buyRule = buyRule;
@@ -30,10 +30,10 @@ namespace Trady.Analysis.Backtest
             return new Builder(_weightings, _buyRule, _sellRule);
         }
 
-        public Builder Buy(Predicate<IndexedCandle> rule)
+        public Builder Buy(Predicate<IIndexedOhlcvData> rule)
             => new Builder(_weightings, ic => _buyRule == null ? rule(ic) : rule(ic) || _buyRule(ic), _sellRule);
 
-        public Builder Sell(Predicate<IndexedCandle> rule)
+        public Builder Sell(Predicate<IIndexedOhlcvData> rule)
             => new Builder(_weightings, _buyRule, ic => _sellRule  == null ? rule(ic) : rule(ic) || _sellRule(ic));
 
         public Runner Build()

--- a/Trady.Analysis/Backtest/Builder.cs
+++ b/Trady.Analysis/Backtest/Builder.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Backtest
 {
     public class Builder
     {
-        private IDictionary<IEnumerable<Candle>, int> _weightings;
+        private IDictionary<IEnumerable<IOhlcvData>, int> _weightings;
         private Predicate<IndexedCandle> _buyRule, _sellRule;
 
         public Builder() : this(null, null, null)
@@ -14,16 +15,16 @@ namespace Trady.Analysis.Backtest
         }
 
         private Builder(
-            IDictionary<IEnumerable<Candle>, int> weightings, 
+            IDictionary<IEnumerable<IOhlcvData>, int> weightings, 
             Predicate<IndexedCandle> buyRule, 
             Predicate<IndexedCandle> sellRule)
         {
-            _weightings = weightings ?? new Dictionary<IEnumerable<Candle>, int>();
+            _weightings = weightings ?? new Dictionary<IEnumerable<IOhlcvData>, int>();
             _buyRule = buyRule;
             _sellRule = sellRule;
         }
 
-        public Builder Add(IEnumerable<Candle> candles, int weighting = 1)
+        public Builder Add(IEnumerable<IOhlcvData> candles, int weighting = 1)
         {
             _weightings.Add(candles, weighting);
             return new Builder(_weightings, _buyRule, _sellRule);

--- a/Trady.Analysis/Backtest/BuySellRuleExecutor.cs
+++ b/Trady.Analysis/Backtest/BuySellRuleExecutor.cs
@@ -6,18 +6,18 @@ using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Backtest
 {
-    public class BuySellRuleExecutor : RuleExecutorBase<Candle, IndexedCandle, (TransactionType, IndexedCandle)>
+    public class BuySellRuleExecutor : RuleExecutorBase<IOhlcvData, IndexedCandle, (TransactionType, IndexedCandle)>
     {
         public BuySellRuleExecutor(
             Func<IndexedCandle, int, (TransactionType, IndexedCandle)> outputFunc, 
-            IAnalyzeContext<Candle> context, 
+            IAnalyzeContext<IOhlcvData> context, 
             Predicate<IndexedCandle> buyRule, 
             Predicate<IndexedCandle> sellRule)
             : base(outputFunc, context, new Predicate<IndexedCandle>[] { buyRule, sellRule })
         {
         }
 
-        public override Func<IEnumerable<Candle>, int, IndexedCandle> IndexedObjectConstructor
+        public override Func<IEnumerable<IOhlcvData>, int, IndexedCandle> IndexedObjectConstructor
             => (l, i) => new IndexedCandle(l, i);
     }
 }

--- a/Trady.Analysis/Backtest/BuySellRuleExecutor.cs
+++ b/Trady.Analysis/Backtest/BuySellRuleExecutor.cs
@@ -6,18 +6,18 @@ using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Backtest
 {
-    public class BuySellRuleExecutor : RuleExecutorBase<IOhlcvData, IndexedCandle, (TransactionType, IndexedCandle)>
+    public class BuySellRuleExecutor : RuleExecutorBase<IOhlcvData, IIndexedOhlcvData, (TransactionType, IIndexedOhlcvData)>
     {
         public BuySellRuleExecutor(
-            Func<IndexedCandle, int, (TransactionType, IndexedCandle)> outputFunc, 
+            Func<IIndexedOhlcvData, int, (TransactionType, IIndexedOhlcvData)> outputFunc, 
             IAnalyzeContext<IOhlcvData> context, 
-            Predicate<IndexedCandle> buyRule, 
-            Predicate<IndexedCandle> sellRule)
-            : base(outputFunc, context, new Predicate<IndexedCandle>[] { buyRule, sellRule })
+            Predicate<IIndexedOhlcvData> buyRule, 
+            Predicate<IIndexedOhlcvData> sellRule)
+            : base(outputFunc, context, new[] { buyRule, sellRule })
         {
         }
 
-        public override Func<IEnumerable<IOhlcvData>, int, IndexedCandle> IndexedObjectConstructor
+        public override Func<IEnumerable<IOhlcvData>, int, IIndexedOhlcvData> IndexedObjectConstructor
             => (l, i) => new IndexedCandle(l, i);
     }
 }

--- a/Trady.Analysis/Backtest/Result.cs
+++ b/Trady.Analysis/Backtest/Result.cs
@@ -2,21 +2,22 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Backtest
 {
     public class Result
     {
-        internal Result(IReadOnlyDictionary<IEnumerable<Candle>, decimal> preAssetCashMap, IDictionary<IEnumerable<Candle>, decimal> postAssetCashMap, IList<Transaction> transactions)
+        internal Result(IReadOnlyDictionary<IEnumerable<IOhlcvData>, decimal> preAssetCashMap, IDictionary<IEnumerable<IOhlcvData>, decimal> postAssetCashMap, IList<Transaction> transactions)
         {
             PreAssetCashMap = preAssetCashMap;
             PostAssetCashMap = postAssetCashMap;
             Transactions = transactions;
         }
 
-        public IReadOnlyDictionary<IEnumerable<Candle>, decimal> PreAssetCashMap { get; }
+        public IReadOnlyDictionary<IEnumerable<IOhlcvData>, decimal> PreAssetCashMap { get; }
 
-        public IDictionary<IEnumerable<Candle>, decimal> PostAssetCashMap { get; }
+        public IDictionary<IEnumerable<IOhlcvData>, decimal> PostAssetCashMap { get; }
 
         public IEnumerable<Transaction> Transactions { get; }
 
@@ -28,17 +29,17 @@ namespace Trady.Analysis.Backtest
 
         public int TotalSellCount => Transactions.Count(t => t.Type == TransactionType.Sell);
 
-        public int BuyCount(IEnumerable<Candle> candles) => Transactions.Count(t => t.Candles.Equals(candles) && t.Type == TransactionType.Buy);
+        public int BuyCount(IEnumerable<IOhlcvData> candles) => Transactions.Count(t => t.IOhlcvDatas.Equals(candles) && t.Type == TransactionType.Buy);
 
-        public int SellCount(IEnumerable<Candle> candles) => Transactions.Count(t => t.Candles.Equals(candles) && t.Type == TransactionType.Sell);
+        public int SellCount(IEnumerable<IOhlcvData> candles) => Transactions.Count(t => t.IOhlcvDatas.Equals(candles) && t.Type == TransactionType.Sell);
 
         public int TotalCorrectedTransactionCount => TotalCorrectedBuyCount + TotalSellCount;
 
         public int TotalCorrectedBuyCount => PreAssetCashMap.Select(ac => ac.Key).Sum(a => CorrectedBuyCount(a));
 
-        public int CorrectedBuyCount(IEnumerable<Candle> candles)
+        public int CorrectedBuyCount(IEnumerable<IOhlcvData> candles)
         {
-            var trans = Transactions.Where(t => t.Candles.Equals(candles));
+            var trans = Transactions.Where(t => t.IOhlcvDatas.Equals(candles));
             if (trans.Any())
             {
                 var lastTrans = trans.ElementAt(trans.Count() - 1);
@@ -59,23 +60,23 @@ namespace Trady.Analysis.Backtest
 
         public decimal TotalPrincipal => PreAssetCashMap.Select(ac => ac.Key).Sum(a => Principal(a));
 
-        public decimal CorrectedProfitLossRatio(IEnumerable<Candle> candles) => CorrectedProfitLoss(candles) / Principal(candles);
+        public decimal CorrectedProfitLossRatio(IEnumerable<IOhlcvData> candles) => CorrectedProfitLoss(candles) / Principal(candles);
 
-        public decimal CorrectedProfitLoss(IEnumerable<Candle> candles) => CorrectedBalance(candles) - Principal(candles);
+        public decimal CorrectedProfitLoss(IEnumerable<IOhlcvData> candles) => CorrectedBalance(candles) - Principal(candles);
 
-        public decimal CorrectedBalance(IEnumerable<Candle> candles)
+        public decimal CorrectedBalance(IEnumerable<IOhlcvData> candles)
         {
             if (!PostAssetCashMap.TryGetValue(candles, out decimal postCash))
                 throw new ArgumentException("Can't get the final cash amount for the corresponding asset!");
 
-            var trans = Transactions.Where(t => t.Candles.Equals(candles));
+            var trans = Transactions.Where(t => t.IOhlcvDatas.Equals(candles));
             if (trans.Any() && trans.Last().Type == TransactionType.Buy)
                 postCash += trans.Last().AbsoluteCashFlow;
 
             return postCash;
         }
 
-        public decimal Principal(IEnumerable<Candle> candles)
+        public decimal Principal(IEnumerable<IOhlcvData> candles)
         {
             if (!PreAssetCashMap.TryGetValue(candles, out decimal initial))
                 throw new ArgumentException("Can't get the final cash amount for the corresponding asset!");

--- a/Trady.Analysis/Backtest/Transaction.cs
+++ b/Trady.Analysis/Backtest/Transaction.cs
@@ -1,14 +1,15 @@
 using System;
 using System.Collections.Generic;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Backtest
 {
     public class Transaction : IEquatable<Transaction>
     {
-        public Transaction(IEnumerable<Candle> candles, int index, DateTime dateTime, TransactionType type, int quantity, decimal absCashFlow)
+        public Transaction(IEnumerable<IOhlcvData> candles, int index, DateTime dateTime, TransactionType type, int quantity, decimal absCashFlow)
         {
-            Candles = candles;
+            IOhlcvDatas = candles;
             Index = index;
             DateTime = dateTime;
             Type = type;
@@ -16,7 +17,7 @@ namespace Trady.Analysis.Backtest
             AbsoluteCashFlow = absCashFlow;
         }
 
-        public IEnumerable<Candle> Candles { get; }
+        public IEnumerable<IOhlcvData> IOhlcvDatas { get; }
 
         public DateTime DateTime { get; }
 
@@ -29,6 +30,6 @@ namespace Trady.Analysis.Backtest
         public decimal AbsoluteCashFlow { get; }
 
         public bool Equals(Transaction other)
-            => Candles.Equals(other.Candles) && Index == other.Index && Type == other.Type && Quantity == other.Quantity && AbsoluteCashFlow == other.AbsoluteCashFlow;
+            => IOhlcvDatas.Equals(other.IOhlcvDatas) && Index == other.Index && Type == other.Type && Quantity == other.Quantity && AbsoluteCashFlow == other.AbsoluteCashFlow;
     }
 }

--- a/Trady.Analysis/Candlestick/Bearish.cs
+++ b/Trady.Analysis/Candlestick/Bearish.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -23,9 +24,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class Bearish : Bearish<Candle, AnalyzableTick<bool>>
+    public class Bearish : Bearish<IOhlcvData, AnalyzableTick<bool>>
     {
-        public Bearish(IEnumerable<Candle> inputs)
+        public Bearish(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/BearishAbandonedBaby.cs
+++ b/Trady.Analysis/Candlestick/BearishAbandonedBaby.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -57,9 +58,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class BearishAbandonedBaby : BearishAbandonedBaby<Candle, AnalyzableTick<bool?>>
+    public class BearishAbandonedBaby : BearishAbandonedBaby<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public BearishAbandonedBaby(IEnumerable<Candle> inputs, int upTrendPeriodCount = 3, int longPeriodCount = 20, decimal longThreshold = 0.75M, decimal dojiThreshold = 0.1M)
+        public BearishAbandonedBaby(IEnumerable<IOhlcvData> inputs, int upTrendPeriodCount = 3, int longPeriodCount = 20, decimal longThreshold = 0.75M, decimal dojiThreshold = 0.1M)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), upTrendPeriodCount, longPeriodCount, longThreshold, dojiThreshold)
         {
         }

--- a/Trady.Analysis/Candlestick/BearishEngulfingPattern.cs
+++ b/Trady.Analysis/Candlestick/BearishEngulfingPattern.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -45,9 +46,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class BearishEngulfingPattern : BearishEngulfingPattern<Candle, AnalyzableTick<bool?>>
+    public class BearishEngulfingPattern : BearishEngulfingPattern<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public BearishEngulfingPattern(IEnumerable<Candle> inputs, int upTrendPeriodCount = 3)
+        public BearishEngulfingPattern(IEnumerable<IOhlcvData> inputs, int upTrendPeriodCount = 3)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), upTrendPeriodCount)
         {
         }

--- a/Trady.Analysis/Candlestick/BearishLongDay.cs
+++ b/Trady.Analysis/Candlestick/BearishLongDay.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -36,9 +37,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class BearishLongDay : BearishLongDay<Candle, AnalyzableTick<bool>>
+    public class BearishLongDay : BearishLongDay<IOhlcvData, AnalyzableTick<bool>>
     {
-        public BearishLongDay(IEnumerable<Candle> inputs, int periodCount = 20, decimal threshold = 0.75M)
+        public BearishLongDay(IEnumerable<IOhlcvData> inputs, int periodCount = 20, decimal threshold = 0.75M)
             : base(inputs, i => (i.Open, i.Close), periodCount, threshold)
         {
         }

--- a/Trady.Analysis/Candlestick/BearishShortDay.cs
+++ b/Trady.Analysis/Candlestick/BearishShortDay.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -37,9 +38,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class BearishShortDay : BearishShortDay<Candle, AnalyzableTick<bool>>
+    public class BearishShortDay : BearishShortDay<IOhlcvData, AnalyzableTick<bool>>
     {
-        public BearishShortDay(IEnumerable<Candle> inputs, int periodCount = 20, decimal threshold = 0.25M)
+        public BearishShortDay(IEnumerable<IOhlcvData> inputs, int periodCount = 20, decimal threshold = 0.25M)
             : base(inputs, i => (i.Open, i.Close), periodCount, threshold)
         {
         }

--- a/Trady.Analysis/Candlestick/Bullish.cs
+++ b/Trady.Analysis/Candlestick/Bullish.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -23,9 +24,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class Bullish : Bullish<Candle, AnalyzableTick<bool>>
+    public class Bullish : Bullish<IOhlcvData, AnalyzableTick<bool>>
     {
-        public Bullish(IEnumerable<Candle> inputs)
+        public Bullish(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/BullishAbandonedBaby.cs
+++ b/Trady.Analysis/Candlestick/BullishAbandonedBaby.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -58,9 +59,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class BullishAbandonedBaby : BullishAbandonedBaby<Candle, AnalyzableTick<bool?>>
+    public class BullishAbandonedBaby : BullishAbandonedBaby<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public BullishAbandonedBaby(IEnumerable<Candle> inputs, int downTrendPeriodCount = 3, int longPeriodCount = 20, decimal longThreshold = 0.75M, decimal dojiThreshold = 0.1M)
+        public BullishAbandonedBaby(IEnumerable<IOhlcvData> inputs, int downTrendPeriodCount = 3, int longPeriodCount = 20, decimal longThreshold = 0.75M, decimal dojiThreshold = 0.1M)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), downTrendPeriodCount, longPeriodCount, longThreshold, dojiThreshold)
         {
         }

--- a/Trady.Analysis/Candlestick/BullishEngulfingPattern.cs
+++ b/Trady.Analysis/Candlestick/BullishEngulfingPattern.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -45,9 +46,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class BullishEngulfingPattern : BullishEngulfingPattern<Candle, AnalyzableTick<bool?>>
+    public class BullishEngulfingPattern : BullishEngulfingPattern<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public BullishEngulfingPattern(IEnumerable<Candle> inputs, int downTrendPeriodCount = 3)
+        public BullishEngulfingPattern(IEnumerable<IOhlcvData> inputs, int downTrendPeriodCount = 3)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), downTrendPeriodCount)
         {
         }

--- a/Trady.Analysis/Candlestick/BullishLongDay.cs
+++ b/Trady.Analysis/Candlestick/BullishLongDay.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -39,9 +40,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class BullishLongDay : BullishLongDay<Candle, AnalyzableTick<bool>>
+    public class BullishLongDay : BullishLongDay<IOhlcvData, AnalyzableTick<bool>>
     {
-        public BullishLongDay(IEnumerable<Candle> inputs, int periodCount = 20, decimal threshold = 0.75M)
+        public BullishLongDay(IEnumerable<IOhlcvData> inputs, int periodCount = 20, decimal threshold = 0.75M)
             : base(inputs, i => (i.Open, i.Close), periodCount, threshold)
         {
         }

--- a/Trady.Analysis/Candlestick/BullishShortDay.cs
+++ b/Trady.Analysis/Candlestick/BullishShortDay.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -40,9 +41,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class BullishShortDay : BullishShortDay<Candle, AnalyzableTick<bool>>
+    public class BullishShortDay : BullishShortDay<IOhlcvData, AnalyzableTick<bool>>
     {
-        public BullishShortDay(IEnumerable<Candle> inputs, int periodCount = 20, decimal threshold = 0.25M)
+        public BullishShortDay(IEnumerable<IOhlcvData> inputs, int periodCount = 20, decimal threshold = 0.25M)
             : base(inputs, i => (i.Open, i.Close), periodCount, threshold)
         {
         }

--- a/Trady.Analysis/Candlestick/DarkCloudCover.cs
+++ b/Trady.Analysis/Candlestick/DarkCloudCover.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -60,9 +61,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class DarkCloudCover : DarkCloudCover<Candle, AnalyzableTick<bool?>>
+    public class DarkCloudCover : DarkCloudCover<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public DarkCloudCover(IEnumerable<Candle> inputs, int upTrendPeriodCount = 3, int downTrendPeriodCount = 3, int longPeriodCount = 20, decimal longThreshold = 0.75M)
+        public DarkCloudCover(IEnumerable<IOhlcvData> inputs, int upTrendPeriodCount = 3, int downTrendPeriodCount = 3, int longPeriodCount = 20, decimal longThreshold = 0.75M)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), upTrendPeriodCount, downTrendPeriodCount, longPeriodCount, longThreshold)
         {
         }

--- a/Trady.Analysis/Candlestick/Doji.cs
+++ b/Trady.Analysis/Candlestick/Doji.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -26,9 +27,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class Doji : Doji<Candle, AnalyzableTick<bool>>
+    public class Doji : Doji<IOhlcvData, AnalyzableTick<bool>>
     {
-        public Doji(IEnumerable<Candle> inputs, decimal threshold = 0.1M)
+        public Doji(IEnumerable<IOhlcvData> inputs, decimal threshold = 0.1M)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), threshold)
         {
         }

--- a/Trady.Analysis/Candlestick/DownTrend.cs
+++ b/Trady.Analysis/Candlestick/DownTrend.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -39,9 +40,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class DownTrend : DownTrend<Candle, AnalyzableTick<bool?>>
+    public class DownTrend : DownTrend<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public DownTrend(IEnumerable<Candle> inputs, int periodCount = 3)
+        public DownTrend(IEnumerable<IOhlcvData> inputs, int periodCount = 3)
             : base(inputs, i => (i.High, i.Low), periodCount)
         {
         }

--- a/Trady.Analysis/Candlestick/DownsideTasukiGap.cs
+++ b/Trady.Analysis/Candlestick/DownsideTasukiGap.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -35,13 +36,13 @@ namespace Trady.Analysis.Candlestick
         protected override bool? ComputeByIndexImpl(IReadOnlyList<(decimal Open, decimal High, decimal Low, decimal Close)> mappedInputs, int index)
         {
             if (index < 2) return null;
-            bool isWhiteCandleWithinGap = mappedInputs[index].Close < mappedInputs[index - 2].Low && mappedInputs[index].Close > mappedInputs[index - 1].High;
+            bool isWhiteIOhlcvDataWithinGap = mappedInputs[index].Close < mappedInputs[index - 2].Low && mappedInputs[index].Close > mappedInputs[index - 1].High;
             return (_downTrend[index - 1] ?? false) &&
                 _bearish[index - 2] &&
                 mappedInputs[index - 2].Low > mappedInputs[index - 1].High &&
                 _bearish[index - 1] &&
                 _bullish[index] &&
-                isWhiteCandleWithinGap;
+                isWhiteIOhlcvDataWithinGap;
         }
     }
 
@@ -53,9 +54,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class DownsideTasukiGap : DownsideTasukiGap<Candle, AnalyzableTick<bool?>>
+    public class DownsideTasukiGap : DownsideTasukiGap<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public DownsideTasukiGap(IEnumerable<Candle> inputs, int downTrendPeriodCount = 3, decimal sizeThreshold = 0.1M)
+        public DownsideTasukiGap(IEnumerable<IOhlcvData> inputs, int downTrendPeriodCount = 3, decimal sizeThreshold = 0.1M)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), downTrendPeriodCount, sizeThreshold)
         {
         }

--- a/Trady.Analysis/Candlestick/DragonflyDoji.cs
+++ b/Trady.Analysis/Candlestick/DragonflyDoji.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -41,9 +42,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class DragonifyDoji : DragonflyDoji<Candle, AnalyzableTick<bool>>
+    public class DragonifyDoji : DragonflyDoji<IOhlcvData, AnalyzableTick<bool>>
     {
-        public DragonifyDoji(IEnumerable<Candle> inputs, decimal dojiThreshold = 0.1M, decimal shadowThreshold = 0.1M)
+        public DragonifyDoji(IEnumerable<IOhlcvData> inputs, decimal dojiThreshold = 0.1M, decimal shadowThreshold = 0.1M)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), dojiThreshold, shadowThreshold)
         {
         }

--- a/Trady.Analysis/Candlestick/EveningDojiStar.cs
+++ b/Trady.Analysis/Candlestick/EveningDojiStar.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -60,9 +61,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class EveningDojiStar : EveningDojiStar<Candle, AnalyzableTick<bool?>>
+    public class EveningDojiStar : EveningDojiStar<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public EveningDojiStar(IEnumerable<Candle> inputs, int upTrendPeriodCount = 3, int periodCount = 20, decimal longThreshold = 0.75M, decimal dojiThreshold = 0.25M, decimal threshold = 0.1M)
+        public EveningDojiStar(IEnumerable<IOhlcvData> inputs, int upTrendPeriodCount = 3, int periodCount = 20, decimal longThreshold = 0.75M, decimal dojiThreshold = 0.25M, decimal threshold = 0.1M)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), upTrendPeriodCount, periodCount, longThreshold, dojiThreshold, threshold)
         {
         }

--- a/Trady.Analysis/Candlestick/EveningStar.cs
+++ b/Trady.Analysis/Candlestick/EveningStar.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -64,9 +65,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class EveningStar : EveningStar<Candle, AnalyzableTick<bool?>>
+    public class EveningStar : EveningStar<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public EveningStar(IEnumerable<Candle> inputs, int upTrendPeriodCount = 3, int periodCount = 20, decimal shortThreshold = 0.25M, decimal longThreshold = 0.75M, decimal threshold = 0.1M)
+        public EveningStar(IEnumerable<IOhlcvData> inputs, int upTrendPeriodCount = 3, int periodCount = 20, decimal shortThreshold = 0.25M, decimal longThreshold = 0.75M, decimal threshold = 0.1M)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), upTrendPeriodCount, periodCount, shortThreshold, longThreshold, threshold)
         {
         }

--- a/Trady.Analysis/Candlestick/FallingThreeMethods.cs
+++ b/Trady.Analysis/Candlestick/FallingThreeMethods.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -67,9 +68,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class FallingThreeMethods : FallingThreeMethods<Candle, AnalyzableTick<bool?>>
+    public class FallingThreeMethods : FallingThreeMethods<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public FallingThreeMethods(IEnumerable<Candle> inputs, int downTrendPeriodCount = 3, int periodCount = 20, decimal shortThreshold = 0.25M, decimal longThreshold = 0.75M)
+        public FallingThreeMethods(IEnumerable<IOhlcvData> inputs, int downTrendPeriodCount = 3, int periodCount = 20, decimal shortThreshold = 0.25M, decimal longThreshold = 0.75M)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), downTrendPeriodCount, periodCount, shortThreshold, longThreshold)
         {
         }

--- a/Trady.Analysis/Candlestick/GravestoneDoji.cs
+++ b/Trady.Analysis/Candlestick/GravestoneDoji.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -41,9 +42,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class GravestoneDoji : GravestoneDoji<Candle, AnalyzableTick<bool>>
+    public class GravestoneDoji : GravestoneDoji<IOhlcvData, AnalyzableTick<bool>>
     {
-        public GravestoneDoji(IEnumerable<Candle> inputs, decimal dojiThreshold = 0.1M, decimal shadowThreshold = 0.1M)
+        public GravestoneDoji(IEnumerable<IOhlcvData> inputs, decimal dojiThreshold = 0.1M, decimal shadowThreshold = 0.1M)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), dojiThreshold, shadowThreshold)
         {
         }

--- a/Trady.Analysis/Candlestick/Hammer.cs
+++ b/Trady.Analysis/Candlestick/Hammer.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -33,9 +34,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class Hammer : Hammer<Candle, AnalyzableTick<bool?>>
+    public class Hammer : Hammer<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public Hammer(IEnumerable<Candle> inputs, int shortPeriodCount = 20, decimal shortThreshold = 0.25M)
+        public Hammer(IEnumerable<IOhlcvData> inputs, int shortPeriodCount = 20, decimal shortThreshold = 0.25M)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), shortPeriodCount, shortThreshold)
         {
         }

--- a/Trady.Analysis/Candlestick/HangingMan.cs
+++ b/Trady.Analysis/Candlestick/HangingMan.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -28,9 +29,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class HangingMan : HangingMan<Candle, AnalyzableTick<bool?>>
+    public class HangingMan : HangingMan<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public HangingMan(IEnumerable<Candle> inputs)
+        public HangingMan(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/Harami.cs
+++ b/Trady.Analysis/Candlestick/Harami.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -28,9 +29,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class Harami : Harami<Candle, AnalyzableTick<bool?>>
+    public class Harami : Harami<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public Harami(IEnumerable<Candle> inputs)
+        public Harami(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/HaramiCross.cs
+++ b/Trady.Analysis/Candlestick/HaramiCross.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -28,9 +29,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class HaramiCross : HaramiCross<Candle, AnalyzableTick<bool?>>
+    public class HaramiCross : HaramiCross<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public HaramiCross(IEnumerable<Candle> inputs)
+        public HaramiCross(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/InvertedHammer.cs
+++ b/Trady.Analysis/Candlestick/InvertedHammer.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -28,9 +29,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class InvertedHammer : InvertedHammer<Candle, AnalyzableTick<bool?>>
+    public class InvertedHammer : InvertedHammer<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public InvertedHammer(IEnumerable<Candle> inputs)
+        public InvertedHammer(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/LongDay.cs
+++ b/Trady.Analysis/Candlestick/LongDay.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
+using Trady.Analysis.Extension;
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -33,9 +35,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class LongDay : LongDay<Candle, AnalyzableTick<bool>>
+    public class LongDay : LongDay<IOhlcvData, AnalyzableTick<bool>>
     {
-        public LongDay(IEnumerable<Candle> inputs, int periodCount = 20, decimal threshold = 0.75M)
+        public LongDay(IEnumerable<IOhlcvData> inputs, int periodCount = 20, decimal threshold = 0.75M)
             : base(inputs, i => (i.Open, i.Close), periodCount, threshold)
         {
         }

--- a/Trady.Analysis/Candlestick/LongLeggedDoji.cs
+++ b/Trady.Analysis/Candlestick/LongLeggedDoji.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -28,9 +29,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class LongLeggedDoji : LongLeggedDoji<Candle, AnalyzableTick<bool?>>
+    public class LongLeggedDoji : LongLeggedDoji<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public LongLeggedDoji(IEnumerable<Candle> inputs)
+        public LongLeggedDoji(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/LongLowerShadow.cs
+++ b/Trady.Analysis/Candlestick/LongLowerShadow.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Trady.Analysis.Indicator;
+
+using Trady.Analysis.Extension;
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -33,9 +34,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class LongLowerShadow : LongLowerShadow<Candle, AnalyzableTick<bool?>>
+    public class LongLowerShadow : LongLowerShadow<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public LongLowerShadow(IEnumerable<Candle> inputs, int periodCount = 20, decimal threshold = 0.25M)
+        public LongLowerShadow(IEnumerable<IOhlcvData> inputs, int periodCount = 20, decimal threshold = 0.25M)
             : base(inputs, i => (i.Open, i.Low, i.Close), periodCount, threshold)
         {
         }

--- a/Trady.Analysis/Candlestick/LongUpperShadow.cs
+++ b/Trady.Analysis/Candlestick/LongUpperShadow.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
+using Trady.Analysis.Extension;
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -32,9 +34,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class LongUpperShadow : LongUpperShadow<Candle, AnalyzableTick<bool?>>
+    public class LongUpperShadow : LongUpperShadow<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public LongUpperShadow(IEnumerable<Candle> inputs, int periodCount = 20, decimal threshold = 0.75M)
+        public LongUpperShadow(IEnumerable<IOhlcvData> inputs, int periodCount = 20, decimal threshold = 0.75M)
             : base(inputs, i => (i.Open, i.High, i.Close), periodCount, threshold)
         {
         }

--- a/Trady.Analysis/Candlestick/Marubozu.cs
+++ b/Trady.Analysis/Candlestick/Marubozu.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -28,9 +29,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class Marubozu : Marubozu<Candle, AnalyzableTick<bool?>>
+    public class Marubozu : Marubozu<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public Marubozu(IEnumerable<Candle> inputs)
+        public Marubozu(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/MorningDojiStar.cs
+++ b/Trady.Analysis/Candlestick/MorningDojiStar.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -64,9 +65,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class MorningDojiStar : MorningDojiStar<Candle, AnalyzableTick<bool?>>
+    public class MorningDojiStar : MorningDojiStar<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public MorningDojiStar(IEnumerable<Candle> inputs, int downTrendPeriodCount = 3, int periodCount = 20, decimal longThreshold = 0.75M, decimal dojiThreshold = 0.25M, decimal threshold = 0.1M)
+        public MorningDojiStar(IEnumerable<IOhlcvData> inputs, int downTrendPeriodCount = 3, int periodCount = 20, decimal longThreshold = 0.75M, decimal dojiThreshold = 0.25M, decimal threshold = 0.1M)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), downTrendPeriodCount, periodCount, longThreshold, dojiThreshold, threshold)
         {
         }

--- a/Trady.Analysis/Candlestick/MorningStar.cs
+++ b/Trady.Analysis/Candlestick/MorningStar.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -63,9 +64,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class MorningStar : MorningStar<Candle, AnalyzableTick<bool?>>
+    public class MorningStar : MorningStar<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public MorningStar(IEnumerable<Candle> inputs, int downTrendPeriodCount = 3, int periodCount = 20, decimal shortThreshold = 0.25M, decimal longThreshold = 0.75M, decimal threshold = 0.1M)
+        public MorningStar(IEnumerable<IOhlcvData> inputs, int downTrendPeriodCount = 3, int periodCount = 20, decimal shortThreshold = 0.25M, decimal longThreshold = 0.75M, decimal threshold = 0.1M)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), downTrendPeriodCount, periodCount, shortThreshold, longThreshold, threshold)
         {
         }

--- a/Trady.Analysis/Candlestick/PiercingLine.cs
+++ b/Trady.Analysis/Candlestick/PiercingLine.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -28,9 +29,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class PiercingLine : PiercingLine<Candle, AnalyzableTick<bool?>>
+    public class PiercingLine : PiercingLine<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public PiercingLine(IEnumerable<Candle> inputs)
+        public PiercingLine(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/RisingThreeMethods.cs
+++ b/Trady.Analysis/Candlestick/RisingThreeMethods.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -66,9 +67,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class RisingThreeMethods : RisingThreeMethods<Candle, AnalyzableTick<bool?>>
+    public class RisingThreeMethods : RisingThreeMethods<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public RisingThreeMethods(IEnumerable<Candle> inputs, int upTrendPeriodCount = 3, int periodCount = 20, decimal shortThreshold = 0.25M, decimal longThreshold = 0.75M)
+        public RisingThreeMethods(IEnumerable<IOhlcvData> inputs, int upTrendPeriodCount = 3, int periodCount = 20, decimal shortThreshold = 0.25M, decimal longThreshold = 0.75M)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), upTrendPeriodCount, periodCount, shortThreshold, longThreshold)
         {
         }

--- a/Trady.Analysis/Candlestick/ShootingStar.cs
+++ b/Trady.Analysis/Candlestick/ShootingStar.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -28,9 +29,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class ShootingStar : ShootingStar<Candle, AnalyzableTick<bool?>>
+    public class ShootingStar : ShootingStar<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public ShootingStar(IEnumerable<Candle> inputs)
+        public ShootingStar(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/ShortDay.cs
+++ b/Trady.Analysis/Candlestick/ShortDay.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
+using Trady.Analysis.Extension;
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -33,9 +35,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class ShortDay : ShortDay<Candle, AnalyzableTick<bool>>
+    public class ShortDay : ShortDay<IOhlcvData, AnalyzableTick<bool>>
     {
-        public ShortDay(IEnumerable<Candle> inputs, int periodCount = 20, decimal threshold = 0.25M)
+        public ShortDay(IEnumerable<IOhlcvData> inputs, int periodCount = 20, decimal threshold = 0.25M)
             : base(inputs, i => (i.Open, i.Close), periodCount, threshold)
         {
         }

--- a/Trady.Analysis/Candlestick/ShortShadow.cs
+++ b/Trady.Analysis/Candlestick/ShortShadow.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -28,9 +29,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class ShortShadow : ShortShadow<Candle, AnalyzableTick<bool?>>
+    public class ShortShadow : ShortShadow<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public ShortShadow(IEnumerable<Candle> inputs)
+        public ShortShadow(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/SpinningTop.cs
+++ b/Trady.Analysis/Candlestick/SpinningTop.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -28,9 +29,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class SpinningTop : SpinningTop<Candle, AnalyzableTick<bool?>>
+    public class SpinningTop : SpinningTop<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public SpinningTop(IEnumerable<Candle> inputs)
+        public SpinningTop(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/Stars.cs
+++ b/Trady.Analysis/Candlestick/Stars.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -28,9 +29,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class Stars : Stars<Candle, AnalyzableTick<bool?>>
+    public class Stars : Stars<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public Stars(IEnumerable<Candle> inputs)
+        public Stars(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/StickSandwich.cs
+++ b/Trady.Analysis/Candlestick/StickSandwich.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -28,9 +29,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class StickSandwich : StickSandwich<Candle, AnalyzableTick<bool?>>
+    public class StickSandwich : StickSandwich<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public StickSandwich(IEnumerable<Candle> inputs)
+        public StickSandwich(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/ThreeBlackCrows.cs
+++ b/Trady.Analysis/Candlestick/ThreeBlackCrows.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -28,9 +29,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class ThreeBlackCrows : ThreeBlackCrows<Candle, AnalyzableTick<bool?>>
+    public class ThreeBlackCrows : ThreeBlackCrows<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public ThreeBlackCrows(IEnumerable<Candle> inputs)
+        public ThreeBlackCrows(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/ThreeWhiteSoldiers.cs
+++ b/Trady.Analysis/Candlestick/ThreeWhiteSoldiers.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -28,9 +29,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class ThreeWhiteSoldiers : ThreeWhiteSoldiers<Candle, AnalyzableTick<bool?>>
+    public class ThreeWhiteSoldiers : ThreeWhiteSoldiers<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public ThreeWhiteSoldiers(IEnumerable<Candle> inputs)
+        public ThreeWhiteSoldiers(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/UpTrend.cs
+++ b/Trady.Analysis/Candlestick/UpTrend.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -39,9 +40,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class UpTrend : UpTrend<Candle, AnalyzableTick<bool?>>
+    public class UpTrend : UpTrend<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public UpTrend(IEnumerable<Candle> inputs, int periodCount = 3)
+        public UpTrend(IEnumerable<IOhlcvData> inputs, int periodCount = 3)
             : base(inputs, i => (i.High, i.Low), periodCount)
         {
         }

--- a/Trady.Analysis/Candlestick/UpsideGapTwoCrows.cs
+++ b/Trady.Analysis/Candlestick/UpsideGapTwoCrows.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -28,9 +29,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class UpsideGapTwoCrows : UpsideGapTwoCrows<Candle, AnalyzableTick<bool?>>
+    public class UpsideGapTwoCrows : UpsideGapTwoCrows<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public UpsideGapTwoCrows(IEnumerable<Candle> inputs)
+        public UpsideGapTwoCrows(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Candlestick/UpsideTasukiGap.cs
+++ b/Trady.Analysis/Candlestick/UpsideTasukiGap.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Candlestick
 {
@@ -35,7 +36,7 @@ namespace Trady.Analysis.Candlestick
         protected override bool? ComputeByIndexImpl(IReadOnlyList<(decimal Open, decimal High, decimal Low, decimal Close)> mappedInputs, int index)
         {
             if (index < 2) return null;
-            bool isBlackCandleWithinGap = (mappedInputs[index].Open > mappedInputs[index - 1].Open) &&
+            bool isBlackIOhlcvDataWithinGap = (mappedInputs[index].Open > mappedInputs[index - 1].Open) &&
                 (mappedInputs[index].Open < mappedInputs[index - 1].Close) &&
                 (mappedInputs[index].Close < mappedInputs[index - 1].Open);
             return (_upTrend[index - 1] ?? false) &&
@@ -43,7 +44,7 @@ namespace Trady.Analysis.Candlestick
                 mappedInputs[index - 2].High < mappedInputs[index - 1].Low &&
                 _bullish[index - 1] &&
                 _bearish[index] &&
-                isBlackCandleWithinGap;
+                isBlackIOhlcvDataWithinGap;
         }
     }
 
@@ -55,9 +56,9 @@ namespace Trady.Analysis.Candlestick
         }
     }
 
-    public class UpsideTasukiGap : UpsideTasukiGap<Candle, AnalyzableTick<bool?>>
+    public class UpsideTasukiGap : UpsideTasukiGap<IOhlcvData, AnalyzableTick<bool?>>
     {
-        public UpsideTasukiGap(IEnumerable<Candle> inputs, int upTrendPeriodCount = 3, decimal sizeThreshold = 0.1M)
+        public UpsideTasukiGap(IEnumerable<IOhlcvData> inputs, int upTrendPeriodCount = 3, decimal sizeThreshold = 0.1M)
             : base(inputs, i => (i.Open, i.High, i.Low, i.Close), upTrendPeriodCount, sizeThreshold)
         {
         }

--- a/Trady.Analysis/Extension/CandlesExtension.cs
+++ b/Trady.Analysis/Extension/CandlesExtension.cs
@@ -1,168 +1,168 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Indicator;
 using Trady.Analysis.Infrastructure;
-using Trady.Core;
 using Trady.Core.Infrastructure;
 
-namespace Trady.Analysis
+namespace Trady.Analysis.Extension
 {
-    public static class CandlesExtension
+    public static class IOhlcvDatasExtension
     {
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Func(this IEnumerable<Candle> candles, Func<IReadOnlyList<Candle>, int, IReadOnlyList<decimal>, IAnalyzeContext<Candle>, decimal?> func, params decimal[] parameters)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Func(this IEnumerable<IOhlcvData> candles, Func<IReadOnlyList<IOhlcvData>, int, IReadOnlyList<decimal>, IAnalyzeContext<IOhlcvData>, decimal?> func, params decimal[] parameters)
             => func.AsAnalyzable(candles, parameters).Compute();
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Func(this IEnumerable<Candle> candles, string name, params decimal[] parameters)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Func(this IEnumerable<IOhlcvData> candles, string name, params decimal[] parameters)
             => FuncAnalyzableFactory.CreateAnalyzable(name, candles, parameters).Compute();
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> AccumDist(this IEnumerable<Candle> candles, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> AccumDist(this IEnumerable<IOhlcvData> candles, int? startIndex = null, int? endIndex = null)
             => new AccumulationDistributionLine(candles).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<(decimal? Up, decimal? Down)>> Aroon(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<(decimal? Up, decimal? Down)>> Aroon(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new Aroon(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> AroonOsc(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> AroonOsc(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new AroonOscillator(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Adx(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Adx(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new AverageDirectionalIndex(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Adxr(this IEnumerable<Candle> candles, int periodCount, int adxrPeriodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Adxr(this IEnumerable<IOhlcvData> candles, int periodCount, int adxrPeriodCount, int? startIndex = null, int? endIndex = null)
             => new AverageDirectionalIndexRating(candles, periodCount, adxrPeriodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Atr(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Atr(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new AverageTrueRange(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<(decimal? LowerBand, decimal? MiddleBand, decimal? UpperBand)>> Bb(this IEnumerable<Candle> candles, int periodCount, decimal sdCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<(decimal? LowerBand, decimal? MiddleBand, decimal? UpperBand)>> Bb(this IEnumerable<IOhlcvData> candles, int periodCount, decimal sdCount, int? startIndex = null, int? endIndex = null)
             => new BollingerBands(candles, periodCount, sdCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> BbWidth(this IEnumerable<Candle> candles, int periodCount, decimal sdCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> BbWidth(this IEnumerable<IOhlcvData> candles, int periodCount, decimal sdCount, int? startIndex = null, int? endIndex = null)
             => new BollingerBandWidth(candles, periodCount, sdCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<(decimal? Long, decimal? Short)>> Chandlr(this IEnumerable<Candle> candles, int periodCount, decimal atrCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<(decimal? Long, decimal? Short)>> Chandlr(this IEnumerable<IOhlcvData> candles, int periodCount, decimal atrCount, int? startIndex = null, int? endIndex = null)
             => new ChandelierExit(candles, periodCount, atrCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> CloseDiff(this IEnumerable<Candle> candles, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> CloseDiff(this IEnumerable<IOhlcvData> candles, int? startIndex = null, int? endIndex = null)
             => new ClosePriceChange(candles).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> CloseDiff(this IEnumerable<Candle> candles, int numberOfDays, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> CloseDiff(this IEnumerable<IOhlcvData> candles, int numberOfDays, int? startIndex = null, int? endIndex = null)
             => new ClosePriceChange(candles, numberOfDays).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> ClosePcDiff(this IEnumerable<Candle> candles, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> ClosePcDiff(this IEnumerable<IOhlcvData> candles, int? startIndex = null, int? endIndex = null)
             => new ClosePricePercentageChange(candles).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> ClosePcDiff(this IEnumerable<Candle> candles, int numberOfDays, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> ClosePcDiff(this IEnumerable<IOhlcvData> candles, int numberOfDays, int? startIndex = null, int? endIndex = null)
             => new ClosePricePercentageChange(candles, numberOfDays).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Dmi(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Dmi(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new DirectionalMovementIndex(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Er(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Er(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new EfficiencyRatio(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Ema(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Ema(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new ExponentialMovingAverage(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> EmaOsc(this IEnumerable<Candle> candles, int periodCount1, int periodCount2, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> EmaOsc(this IEnumerable<IOhlcvData> candles, int periodCount1, int periodCount2, int? startIndex = null, int? endIndex = null)
             => new ExponentialMovingAverageOscillator(candles, periodCount1, periodCount2).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> HighHigh(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> HighHigh(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new HighestHigh(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> HistHighHigh(this IEnumerable<Candle> candles, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> HistHighHigh(this IEnumerable<IOhlcvData> candles, int? startIndex = null, int? endIndex = null)
             => new HistoricalHighestHigh(candles).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> HistHighClose(this IEnumerable<Candle> candles, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> HistHighClose(this IEnumerable<IOhlcvData> candles, int? startIndex = null, int? endIndex = null)
             => new HistoricalHighestClose(candles).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> HighClose(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> HighClose(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new HighestClose(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<(decimal? ConversionLine, decimal? BaseLine, decimal? LeadingSpanA, decimal? LeadingSpanB, decimal? LaggingSpan)>> Ichimoku(this IEnumerable<Candle> candles, int shortPeriodCount, int middlePeriodCount, int longPeriodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<(decimal? ConversionLine, decimal? BaseLine, decimal? LeadingSpanA, decimal? LeadingSpanB, decimal? LaggingSpan)>> Ichimoku(this IEnumerable<IOhlcvData> candles, int shortPeriodCount, int middlePeriodCount, int longPeriodCount, int? startIndex = null, int? endIndex = null)
             => new IchimokuCloud(candles, shortPeriodCount, middlePeriodCount, longPeriodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Kama(this IEnumerable<Candle> candles, int periodCount, int emaFastPeriodCount, int emaSlowPeriodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Kama(this IEnumerable<IOhlcvData> candles, int periodCount, int emaFastPeriodCount, int emaSlowPeriodCount, int? startIndex = null, int? endIndex = null)
             => new KaufmanAdaptiveMovingAverage(candles, periodCount, emaFastPeriodCount, emaSlowPeriodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> LowLow(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> LowLow(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new LowestLow(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> HistLowLow(this IEnumerable<Candle> candles, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> HistLowLow(this IEnumerable<IOhlcvData> candles, int? startIndex = null, int? endIndex = null)
             => new HistoricalLowestLow(candles).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> HistLowClose(this IEnumerable<Candle> candles, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> HistLowClose(this IEnumerable<IOhlcvData> candles, int? startIndex = null, int? endIndex = null)
             => new HistoricalLowestClose(candles).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> LowClose(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> LowClose(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new LowestClose(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Mdi(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Mdi(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new MinusDirectionalIndicator(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Mdm(this IEnumerable<Candle> candles, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Mdm(this IEnumerable<IOhlcvData> candles, int? startIndex = null, int? endIndex = null)
             => new MinusDirectionalMovement(candles).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Mma(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Mma(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new ModifiedMovingAverage(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<(decimal? MacdLine, decimal? SignalLine, decimal? MacdHistogram)>> Macd(this IEnumerable<Candle> candles, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<(decimal? MacdLine, decimal? SignalLine, decimal? MacdHistogram)>> Macd(this IEnumerable<IOhlcvData> candles, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount, int? startIndex = null, int? endIndex = null)
             => new MovingAverageConvergenceDivergence(candles, emaPeriodCount1, emaPeriodCount2, demPeriodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> MacdHist(this IEnumerable<Candle> candles, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> MacdHist(this IEnumerable<IOhlcvData> candles, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount, int? startIndex = null, int? endIndex = null)
 	        => new MovingAverageConvergenceDivergenceHistogram(candles, emaPeriodCount1, emaPeriodCount2, demPeriodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Obv(this IEnumerable<Candle> candles, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Obv(this IEnumerable<IOhlcvData> candles, int? startIndex = null, int? endIndex = null)
             => new OnBalanceVolume(candles).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Pdi(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Pdi(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new PlusDirectionalIndicator(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Pdm(this IEnumerable<Candle> candles, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Pdm(this IEnumerable<IOhlcvData> candles, int? startIndex = null, int? endIndex = null)
             => new PlusDirectionalMovement(candles).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Rsv(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Rsv(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new RawStochasticsValue(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Rs(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Rs(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new RelativeStrength(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Rsi(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Rsi(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new RelativeStrengthIndex(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Sma(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Sma(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new SimpleMovingAverage(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> SmaOsc(this IEnumerable<Candle> candles, int periodCount1, int periodCount2, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> SmaOsc(this IEnumerable<IOhlcvData> candles, int periodCount1, int periodCount2, int? startIndex = null, int? endIndex = null)
             => new SimpleMovingAverageOscillator(candles, periodCount1, periodCount2).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Sd(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Sd(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
             => new StandardDeviation(candles, periodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<(decimal? K, decimal? D, decimal? J)>> FastSto(this IEnumerable<Candle> candles, int periodCount, int smaPeriodCount, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<(decimal? K, decimal? D, decimal? J)>> FastSto(this IEnumerable<IOhlcvData> candles, int periodCount, int smaPeriodCount, int? startIndex = null, int? endIndex = null)
             => new Stochastics.Fast(candles, periodCount, smaPeriodCount).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<(decimal? K, decimal? D, decimal? J)>> FullSto(this IEnumerable<Candle> candles, int periodCount, int smaPeriodCountK, int smaPeriodCountD, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<(decimal? K, decimal? D, decimal? J)>> FullSto(this IEnumerable<IOhlcvData> candles, int periodCount, int smaPeriodCountK, int smaPeriodCountD, int? startIndex = null, int? endIndex = null)
             => new Stochastics.Full(candles, periodCount, smaPeriodCountK, smaPeriodCountD).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<(decimal? K, decimal? D, decimal? J)>> SlowSto(this IEnumerable<Candle> candles, int periodCount, int smaPeriodCountD, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<(decimal? K, decimal? D, decimal? J)>> SlowSto(this IEnumerable<IOhlcvData> candles, int periodCount, int smaPeriodCountD, int? startIndex = null, int? endIndex = null)
             => new Stochastics.Slow(candles, periodCount, smaPeriodCountD).Compute(startIndex, endIndex);
 
-		public static IReadOnlyList<AnalyzableTick<decimal?>> FastStoOsc(this IEnumerable<Candle> candles, int periodCount, int smaPeriodCount, int? startIndex = null, int? endIndex = null)
+		public static IReadOnlyList<AnalyzableTick<decimal?>> FastStoOsc(this IEnumerable<IOhlcvData> candles, int periodCount, int smaPeriodCount, int? startIndex = null, int? endIndex = null)
 	        => new StochasticsOscillator.Fast(candles, periodCount, smaPeriodCount).Compute(startIndex, endIndex);
 
-		public static IReadOnlyList<AnalyzableTick<decimal?>> FullStoOsc(this IEnumerable<Candle> candles, int periodCount, int smaPeriodCountK, int smaPeriodCountD, int? startIndex = null, int? endIndex = null)
+		public static IReadOnlyList<AnalyzableTick<decimal?>> FullStoOsc(this IEnumerable<IOhlcvData> candles, int periodCount, int smaPeriodCountK, int smaPeriodCountD, int? startIndex = null, int? endIndex = null)
 			=> new StochasticsOscillator.Full(candles, periodCount, smaPeriodCountK, smaPeriodCountD).Compute(startIndex, endIndex);
 
-		public static IReadOnlyList<AnalyzableTick<decimal?>> SlowStoOsc(this IEnumerable<Candle> candles, int periodCount, int smaPeriodCountD, int? startIndex = null, int? endIndex = null)
+		public static IReadOnlyList<AnalyzableTick<decimal?>> SlowStoOsc(this IEnumerable<IOhlcvData> candles, int periodCount, int smaPeriodCountD, int? startIndex = null, int? endIndex = null)
 			=> new StochasticsOscillator.Slow(candles, periodCount, smaPeriodCountD).Compute(startIndex, endIndex);
 
-        public static IReadOnlyList<AnalyzableTick<decimal?>> Tr(this IEnumerable<Candle> candles, int? startIndex = null, int? endIndex = null)
+        public static IReadOnlyList<AnalyzableTick<decimal?>> Tr(this IEnumerable<IOhlcvData> candles, int? startIndex = null, int? endIndex = null)
             => new TrueRange(candles).Compute(startIndex, endIndex);
 
-		public static IReadOnlyList<AnalyzableTick<decimal?>> Median(this IEnumerable<Candle> candles, int periodCount, int? startIndex = null, int? endIndex = null)
+		public static IReadOnlyList<AnalyzableTick<decimal?>> Median(this IEnumerable<IOhlcvData> candles, int periodCount, int? startIndex = null, int? endIndex = null)
 	        => new Median(candles, periodCount).Compute(startIndex, endIndex);
 
-		public static IReadOnlyList<AnalyzableTick<decimal?>> Percentile(this IEnumerable<Candle> candles, int periodCount, decimal percent, int? startIndex = null, int? endIndex = null)
+		public static IReadOnlyList<AnalyzableTick<decimal?>> Percentile(this IEnumerable<IOhlcvData> candles, int periodCount, decimal percent, int? startIndex = null, int? endIndex = null)
 	        => new Percentile(candles, periodCount, percent).Compute(startIndex, endIndex);
     }
 }

--- a/Trady.Analysis/Extension/FuncExtension.cs
+++ b/Trady.Analysis/Extension/FuncExtension.cs
@@ -1,14 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Indicator;
-using Trady.Core;
 using Trady.Core.Infrastructure;
 
-namespace Trady.Analysis
+namespace Trady.Analysis.Extension
 {
     public static class FuncExtension
     {
-        public static FuncAnalyzable<Candle, AnalyzableTick<decimal?>> AsAnalyzable(this Func<IReadOnlyList<Candle>, int, IReadOnlyList<decimal>, IAnalyzeContext<Candle>, decimal?> func, IEnumerable<Candle> inputs, params decimal[] parameters)
+        public static FuncAnalyzable<IOhlcvData, AnalyzableTick<decimal?>> AsAnalyzable(this Func<IReadOnlyList<IOhlcvData>, int, IReadOnlyList<decimal>, IAnalyzeContext<IOhlcvData>, decimal?> func, IEnumerable<IOhlcvData> inputs, params decimal[] parameters)
             => new FuncAnalyzable(inputs, parameters).Init(func);
 
         public static FuncAnalyzable<TInput, decimal?> AsAnalyzable<TInput>(this Func<IReadOnlyList<TInput>, int, IReadOnlyList<decimal> ,IAnalyzeContext<TInput>, decimal?> func, IEnumerable<TInput> inputs, params decimal[] parameters)

--- a/Trady.Analysis/Extension/IndexedCandleExtension.cs
+++ b/Trady.Analysis/Extension/IndexedCandleExtension.cs
@@ -1,196 +1,197 @@
 ﻿using Trady.Analysis.Indicator;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Extension
 {
     public static class IndexedIOhlcvDataExtension
     {
-        public static decimal? ClosePriceChange(this IndexedCandle ic)
+        public static decimal? ClosePriceChange(this IIndexedOhlcvData ic)
             => ic.Get<ClosePriceChange>(1)[ic.Index].Tick;
 
-        public static decimal? ClosePricePercentageChange(this IndexedCandle ic)
+        public static decimal? ClosePricePercentageChange(this IIndexedOhlcvData ic)
             => ic.Get<ClosePricePercentageChange>(1)[ic.Index].Tick;
 
-        public static bool IsBullish(this IndexedCandle ic)
+        public static bool IsBullish(this IIndexedOhlcvData ic)
             => ic.Get<ClosePriceChange>()[ic.Index].Tick.IsPositive();
 
-        public static bool IsBearish(this IndexedCandle ic)
+        public static bool IsBearish(this IIndexedOhlcvData ic)
             => ic.Get<ClosePriceChange>()[ic.Index].Tick.IsNegative();
 
-        public static bool IsAccumDistBullish(this IndexedCandle ic)
+        public static bool IsAccumDistBullish(this IIndexedOhlcvData ic)
             => ic.Get<AccumulationDistributionLine>().Diff(ic.Index).Tick.IsPositive();
 
-        public static bool IsAccumDistBearish(this IndexedCandle ic)
+        public static bool IsAccumDistBearish(this IIndexedOhlcvData ic)
             => ic.Get<AccumulationDistributionLine>().Diff(ic.Index).Tick.IsNegative();
 
-        public static bool IsObvBullish(this IndexedCandle ic)
+        public static bool IsObvBullish(this IIndexedOhlcvData ic)
             => ic.Get<OnBalanceVolume>().Diff(ic.Index).Tick.IsPositive();
 
-        public static bool IsObvBearish(this IndexedCandle ic)
+        public static bool IsObvBearish(this IIndexedOhlcvData ic)
             => ic.Get<OnBalanceVolume>().Diff(ic.Index).Tick.IsNegative();
 
-        public static bool IsInBbRange(this IndexedCandle ic, int periodCount, int sdCount)
+        public static bool IsInBbRange(this IIndexedOhlcvData ic, int periodCount, int sdCount)
             => ic.Get<BollingerBands>(periodCount, sdCount)[ic.Index].Tick.IsTrue((low, mid, up) => ic.Close >= low && ic.Close <= up);
 
-        public static bool IsAboveBbUp(this IndexedCandle ic, int periodCount, int sdCount)
+        public static bool IsAboveBbUp(this IIndexedOhlcvData ic, int periodCount, int sdCount)
             => ic.Get<BollingerBands>(periodCount, sdCount)[ic.Index].Tick.IsTrue((low, mid, up) => ic.Close > up);
 
-        public static bool IsBelowBbLow(this IndexedCandle ic, int periodCount, int sdCount)
+        public static bool IsBelowBbLow(this IIndexedOhlcvData ic, int periodCount, int sdCount)
             => ic.Get<BollingerBands>(periodCount, sdCount)[ic.Index].Tick.IsTrue((low, mid, up) => ic.Close < low);
 
-        public static bool IsRsiOverbought(this IndexedCandle ic, int periodCount)
+        public static bool IsRsiOverbought(this IIndexedOhlcvData ic, int periodCount)
             => ic.Get<RelativeStrengthIndex>(periodCount)[ic.Index].Tick.IsTrue(t => t >= 70);
 
-        public static bool IsRsiOversold(this IndexedCandle ic, int periodCount)
+        public static bool IsRsiOversold(this IIndexedOhlcvData ic, int periodCount)
             => ic.Get<RelativeStrengthIndex>(periodCount)[ic.Index].Tick.IsTrue(t => t <= 30);
 
-        public static bool IsFastStoOverbought(this IndexedCandle ic, int periodCount, int smaPeriodCount)
+        public static bool IsFastStoOverbought(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCount)
             => ic.Get<Stochastics.Fast>(periodCount, smaPeriodCount)[ic.Index].Tick.IsTrue((k, d, j) => k >= 80);
 
-        public static bool IsFullStoOverbought(this IndexedCandle ic, int periodCount, int smaPeriodCountK, int smaPeriodCountD)
+        public static bool IsFullStoOverbought(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCountK, int smaPeriodCountD)
             => ic.Get<Stochastics.Full>(periodCount, smaPeriodCountK, smaPeriodCountD)[ic.Index].Tick.IsTrue((k, d, j) => k >= 80);
 
-        public static bool IsSlowStoOverbought(this IndexedCandle ic, int periodCount, int smaPeriodCountD)
+        public static bool IsSlowStoOverbought(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCountD)
             => ic.Get<Stochastics.Slow>(periodCount, smaPeriodCountD)[ic.Index].Tick.IsTrue((k, d, j) => k >= 80);
 
-        public static bool IsFastStoOversold(this IndexedCandle ic, int periodCount, int smaPeriodCount)
+        public static bool IsFastStoOversold(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCount)
             => ic.Get<Stochastics.Fast>(periodCount, smaPeriodCount)[ic.Index].Tick.IsTrue((k, d, j) => k <= 20);
 
-        public static bool IsFullStoOversold(this IndexedCandle ic, int periodCount, int smaPeriodCountK, int smaPeriodCountD)
+        public static bool IsFullStoOversold(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCountK, int smaPeriodCountD)
             => ic.Get<Stochastics.Full>(periodCount, smaPeriodCountK, smaPeriodCountD)[ic.Index].Tick.IsTrue((k, d, j) => k <= 20);
 
-        public static bool IsSlowStoOversold(this IndexedCandle ic, int periodCount, int smaPeriodCountD)
+        public static bool IsSlowStoOversold(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCountD)
             => ic.Get<Stochastics.Slow>(periodCount, smaPeriodCountD)[ic.Index].Tick.IsTrue((k, d, j) => k <= 20);
 
-        public static bool IsAboveSma(this IndexedCandle ic, int periodCount)
+        public static bool IsAboveSma(this IIndexedOhlcvData ic, int periodCount)
             => ic.Get<SimpleMovingAverage>(periodCount)[ic.Index].Tick.IsTrue(t => ic.Close > t);
 
-        public static bool IsAboveEma(this IndexedCandle ic, int periodCount)
+        public static bool IsAboveEma(this IIndexedOhlcvData ic, int periodCount)
             => ic.Get<ExponentialMovingAverage>(periodCount)[ic.Index].Tick.IsTrue(t => ic.Close > t);
 
-        public static bool IsBelowSma(this IndexedCandle ic, int periodCount)
+        public static bool IsBelowSma(this IIndexedOhlcvData ic, int periodCount)
             => ic.Get<SimpleMovingAverage>(periodCount)[ic.Index].Tick.IsTrue(t => ic.Close < t);
 
-        public static bool IsBelowEma(this IndexedCandle ic, int periodCount)
+        public static bool IsBelowEma(this IIndexedOhlcvData ic, int periodCount)
             => ic.Get<ExponentialMovingAverage>(periodCount)[ic.Index].Tick.IsTrue(t => ic.Close < t);
 
-        public static bool IsSmaBullish(this IndexedCandle ic, int periodCount)
+        public static bool IsSmaBullish(this IIndexedOhlcvData ic, int periodCount)
             => ic.Get<SimpleMovingAverage>(periodCount).Diff(ic.Index).Tick.IsPositive();
 
-        public static bool IsSmaBearish(this IndexedCandle ic, int periodCount)
+        public static bool IsSmaBearish(this IIndexedOhlcvData ic, int periodCount)
             => ic.Get<SimpleMovingAverage>(periodCount).Diff(ic.Index).Tick.IsNegative();
 
-        public static bool IsSmaOscBullish(this IndexedCandle ic, int periodCount1, int periodCount2)
+        public static bool IsSmaOscBullish(this IIndexedOhlcvData ic, int periodCount1, int periodCount2)
             => ic.Get<SimpleMovingAverageOscillator>(periodCount1, periodCount2).Diff(ic.Index).Tick.IsPositive();
 
-        public static bool IsSmaOscBearish(this IndexedCandle ic, int periodCount1, int periodCount2)
+        public static bool IsSmaOscBearish(this IIndexedOhlcvData ic, int periodCount1, int periodCount2)
             => ic.Get<SimpleMovingAverageOscillator>(periodCount1, periodCount2).Diff(ic.Index).Tick.IsNegative();
 
-        public static bool IsEmaBullish(this IndexedCandle ic, int periodCount)
+        public static bool IsEmaBullish(this IIndexedOhlcvData ic, int periodCount)
             => ic.Get<ExponentialMovingAverage>(periodCount).Diff(ic.Index).Tick.IsPositive();
 
-        public static bool IsEmaBearish(this IndexedCandle ic, int periodCount)
+        public static bool IsEmaBearish(this IIndexedOhlcvData ic, int periodCount)
             => ic.Get<ExponentialMovingAverage>(periodCount).Diff(ic.Index).Tick.IsNegative();
 
-        public static bool IsEmaOscBullish(this IndexedCandle ic, int periodCount1, int periodCount2)
+        public static bool IsEmaOscBullish(this IIndexedOhlcvData ic, int periodCount1, int periodCount2)
             => ic.Get<ExponentialMovingAverageOscillator>(periodCount1, periodCount2).Diff(ic.Index).Tick.IsPositive();
 
-        public static bool IsEmaOscBearish(this IndexedCandle ic, int periodCount1, int periodCount2)
+        public static bool IsEmaOscBearish(this IIndexedOhlcvData ic, int periodCount1, int periodCount2)
             => ic.Get<ExponentialMovingAverageOscillator>(periodCount1, periodCount2).Diff(ic.Index).Tick.IsNegative();
 
-        public static bool IsMacdOscBullish(this IndexedCandle ic, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
+        public static bool IsMacdOscBullish(this IIndexedOhlcvData ic, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
             => ic.Get<MovingAverageConvergenceDivergenceHistogram>(emaPeriodCount1, emaPeriodCount2, demPeriodCount).Diff(ic.Index).Tick.IsPositive();
 
-        public static bool IsMacdOscBearish(this IndexedCandle ic, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
+        public static bool IsMacdOscBearish(this IIndexedOhlcvData ic, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
             => ic.Get<MovingAverageConvergenceDivergenceHistogram>(emaPeriodCount1, emaPeriodCount2, demPeriodCount).Diff(ic.Index).Tick.IsNegative();
 
-        public static bool IsFastStoOscBullish(this IndexedCandle ic, int periodCount, int smaPeriodCount)
+        public static bool IsFastStoOscBullish(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCount)
             => ic.Get<StochasticsOscillator.Fast>(periodCount, smaPeriodCount).Diff(ic.Index).Tick.IsPositive();
 
-        public static bool IsFastStoOscBearish(this IndexedCandle ic, int periodCount, int smaPeriodCount)
+        public static bool IsFastStoOscBearish(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCount)
             => ic.Get<StochasticsOscillator.Fast>(periodCount, smaPeriodCount).Diff(ic.Index).Tick.IsNegative();
 
-        public static bool IsFullStoOscBullish(this IndexedCandle ic, int periodCount, int smaPeriodCountK, int smaPeriodCountD)
+        public static bool IsFullStoOscBullish(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCountK, int smaPeriodCountD)
             => ic.Get<StochasticsOscillator.Full>(periodCount, smaPeriodCountK, smaPeriodCountD).Diff(ic.Index).Tick.IsPositive();
 
-        public static bool IsFullStoOscBearish(this IndexedCandle ic, int periodCount, int smaPeriodCountK, int smaPeriodCountD)
+        public static bool IsFullStoOscBearish(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCountK, int smaPeriodCountD)
             => ic.Get<StochasticsOscillator.Full>(periodCount, smaPeriodCountK, smaPeriodCountD).Diff(ic.Index).Tick.IsNegative();
 
-        public static bool IsSlowStoOscBullish(this IndexedCandle ic, int periodCount, int smaPeriodCountD)
+        public static bool IsSlowStoOscBullish(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCountD)
             => ic.Get<StochasticsOscillator.Slow>(periodCount, smaPeriodCountD).Diff(ic.Index).Tick.IsPositive();
 
-        public static bool IsSlowStoOscBearish(this IndexedCandle ic, int periodCount, int smaPeriodCountD)
+        public static bool IsSlowStoOscBearish(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCountD)
             => ic.Get<StochasticsOscillator.Slow>(periodCount, smaPeriodCountD).Diff(ic.Index).Tick.IsNegative();
 
-        public static bool IsSmaBullishCross(this IndexedCandle ic, int periodCount1, int periodCount2)
+        public static bool IsSmaBullishCross(this IIndexedOhlcvData ic, int periodCount1, int periodCount2)
             => ic.Get<SimpleMovingAverageOscillator>(periodCount1, periodCount2).ComputeNeighbour(ic.Index)
                  .IsTrue((prev, current, _) => prev.Tick.IsNegative() && current.Tick.IsPositive());
 
-        public static bool IsSmaBearishCross(this IndexedCandle ic, int periodCount1, int periodCount2)
+        public static bool IsSmaBearishCross(this IIndexedOhlcvData ic, int periodCount1, int periodCount2)
             => ic.Get<SimpleMovingAverageOscillator>(periodCount1, periodCount2).ComputeNeighbour(ic.Index)
                  .IsTrue((prev, current, _) => prev.Tick.IsPositive() && current.Tick.IsNegative());
 
-        public static bool IsEmaBullishCross(this IndexedCandle ic, int periodCount1, int periodCount2)
+        public static bool IsEmaBullishCross(this IIndexedOhlcvData ic, int periodCount1, int periodCount2)
             => ic.Get<ExponentialMovingAverageOscillator>(periodCount1, periodCount2).ComputeNeighbour(ic.Index)
                  .IsTrue((prev, current, _) => prev.Tick.IsNegative() && current.Tick.IsPositive());
 
-        public static bool IsEmaBearishCross(this IndexedCandle ic, int periodCount1, int periodCount2)
+        public static bool IsEmaBearishCross(this IIndexedOhlcvData ic, int periodCount1, int periodCount2)
             => ic.Get<ExponentialMovingAverageOscillator>(periodCount1, periodCount2).ComputeNeighbour(ic.Index)
                  .IsTrue((prev, current, _) => prev.Tick.IsPositive() && current.Tick.IsNegative());
 
-        public static bool IsMacdBullishCross(this IndexedCandle ic, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
+        public static bool IsMacdBullishCross(this IIndexedOhlcvData ic, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
             => ic.Get<MovingAverageConvergenceDivergenceHistogram>(emaPeriodCount1, emaPeriodCount2, demPeriodCount).ComputeNeighbour(ic.Index)
                  .IsTrue((prev, current, _) => prev.Tick.IsNegative() && current.Tick.IsPositive());
 
-        public static bool IsMacdBearishCross(this IndexedCandle ic, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
+        public static bool IsMacdBearishCross(this IIndexedOhlcvData ic, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
             => ic.Get<MovingAverageConvergenceDivergenceHistogram>(emaPeriodCount1, emaPeriodCount2, demPeriodCount).ComputeNeighbour(ic.Index)
                  .IsTrue((prev, current, _) => prev.Tick.IsPositive() && current.Tick.IsNegative());
 
-        public static bool IsFastStoBullishCross(this IndexedCandle ic, int periodCount, int smaPeriodCount)
+        public static bool IsFastStoBullishCross(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCount)
             => ic.Get<StochasticsOscillator.Fast>(periodCount, smaPeriodCount).ComputeNeighbour(ic.Index)
                  .IsTrue((prev, current, _) => prev.Tick.IsNegative() && current.Tick.IsPositive());
 
-        public static bool IsFastStoBearishCross(this IndexedCandle ic, int periodCount, int smaPeriodCount)
+        public static bool IsFastStoBearishCross(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCount)
             => ic.Get<StochasticsOscillator.Fast>(periodCount, smaPeriodCount).ComputeNeighbour(ic.Index)
                  .IsTrue((prev, current, _) => prev.Tick.IsPositive() && current.Tick.IsNegative());
 
-        public static bool IsFullStoBullishCross(this IndexedCandle ic, int periodCount, int smaPeriodCountK, int smaPeriodCountD)
+        public static bool IsFullStoBullishCross(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCountK, int smaPeriodCountD)
             => ic.Get<StochasticsOscillator.Full>(periodCount, smaPeriodCountK, smaPeriodCountD).ComputeNeighbour(ic.Index)
                  .IsTrue((prev, current, _) => prev.Tick.IsNegative() && current.Tick.IsPositive());
 
-        public static bool IsFullStoBearishCross(this IndexedCandle ic, int periodCount, int smaPeriodCountK, int smaPeriodCountD)
+        public static bool IsFullStoBearishCross(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCountK, int smaPeriodCountD)
             => ic.Get<StochasticsOscillator.Full>(periodCount, smaPeriodCountK, smaPeriodCountD).ComputeNeighbour(ic.Index)
                  .IsTrue((prev, current, _) => prev.Tick.IsPositive() && current.Tick.IsNegative());
 
-        public static bool IsSlowStoBullishCross(this IndexedCandle ic, int periodCount, int smaPeriodCountD)
+        public static bool IsSlowStoBullishCross(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCountD)
             => ic.Get<StochasticsOscillator.Slow>(periodCount, smaPeriodCountD).ComputeNeighbour(ic.Index)
                  .IsTrue((prev, current, _) => prev.Tick.IsNegative() && current.Tick.IsPositive());
 
-        public static bool IsSlowStoBearishCross(this IndexedCandle ic, int periodCount, int smaPeriodCountD)
+        public static bool IsSlowStoBearishCross(this IIndexedOhlcvData ic, int periodCount, int smaPeriodCountD)
             => ic.Get<StochasticsOscillator.Slow>(periodCount, smaPeriodCountD).ComputeNeighbour(ic.Index)
                  .IsTrue((prev, current, _) => prev.Tick.IsPositive() && current.Tick.IsNegative());
 
-        public static bool IsBreakingHistoricalHighestHigh(this IndexedCandle ic)
+        public static bool IsBreakingHistoricalHighestHigh(this IIndexedOhlcvData ic)
             => ic.Get<HistoricalHighestHigh>().Diff(ic.Index).Tick.IsPositive();
 
-        public static bool IsBreakingHistoricalHighestClose(this IndexedCandle ic)
+        public static bool IsBreakingHistoricalHighestClose(this IIndexedOhlcvData ic)
             => ic.Get<HistoricalHighestClose>().Diff(ic.Index).Tick.IsPositive();
 
-        public static bool IsBreakingHistoricalLowestLow(this IndexedCandle ic)
+        public static bool IsBreakingHistoricalLowestLow(this IIndexedOhlcvData ic)
             => ic.Get<HistoricalLowestLow>().Diff(ic.Index).Tick.IsNegative();
 
-        public static bool IsBreakingHistoricalLowestClose(this IndexedCandle ic)
+        public static bool IsBreakingHistoricalLowestClose(this IIndexedOhlcvData ic)
             => ic.Get<HistoricalLowestClose>().Diff(ic.Index).Tick.IsNegative();
 
-        public static bool IsBreakingHighestHigh(this IndexedCandle ic, int periodCount)
+        public static bool IsBreakingHighestHigh(this IIndexedOhlcvData ic, int periodCount)
             => ic.Get<HighestHigh>(periodCount).Diff(ic.Index).Tick.IsPositive();
 
-        public static bool IsBreakingHighestClose(this IndexedCandle ic, int periodCount)
+        public static bool IsBreakingHighestClose(this IIndexedOhlcvData ic, int periodCount)
             => ic.Get<HighestClose>(periodCount).Diff(ic.Index).Tick.IsPositive();
 
-        public static bool IsBreakingLowestLow(this IndexedCandle ic, int periodCount)
+        public static bool IsBreakingLowestLow(this IIndexedOhlcvData ic, int periodCount)
             => ic.Get<LowestLow>(periodCount).Diff(ic.Index).Tick.IsNegative();
 
-        public static bool IsBreakingLowestClose(this IndexedCandle ic, int periodCount)
+        public static bool IsBreakingLowestClose(this IIndexedOhlcvData ic, int periodCount)
             => ic.Get<LowestClose>(periodCount).Diff(ic.Index).Tick.IsNegative();
     }
 }

--- a/Trady.Analysis/Extension/IndexedCandleExtension.cs
+++ b/Trady.Analysis/Extension/IndexedCandleExtension.cs
@@ -1,8 +1,8 @@
 ﻿using Trady.Analysis.Indicator;
 
-namespace Trady.Analysis
+namespace Trady.Analysis.Extension
 {
-    public static class IndexedCandleExtension
+    public static class IndexedIOhlcvDataExtension
     {
         public static decimal? ClosePriceChange(this IndexedCandle ic)
             => ic.Get<ClosePriceChange>(1)[ic.Index].Tick;

--- a/Trady.Analysis/Extension/PredicateExtension.cs
+++ b/Trady.Analysis/Extension/PredicateExtension.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+
 using AnTick = Trady.Analysis.AnalyzableTick<decimal?>;
 using AnTp2Tick = Trady.Analysis.AnalyzableTick<(decimal?, decimal?)>;
 using AnTp3Tick = Trady.Analysis.AnalyzableTick<(decimal?, decimal?, decimal?)>;
 
-namespace Trady.Analysis
+namespace Trady.Analysis.Extension
 {
     public static class PredicateExtension
     {

--- a/Trady.Analysis/Extension/PredicateExtension.cs
+++ b/Trady.Analysis/Extension/PredicateExtension.cs
@@ -4,7 +4,7 @@ using AnTick = Trady.Analysis.AnalyzableTick<decimal?>;
 using AnTp2Tick = Trady.Analysis.AnalyzableTick<(decimal?, decimal?)>;
 using AnTp3Tick = Trady.Analysis.AnalyzableTick<(decimal?, decimal?, decimal?)>;
 
-namespace Trady.Analysis.Extension
+namespace Trady.Analysis
 {
     public static class PredicateExtension
     {

--- a/Trady.Analysis/Extension/TuplesExtension.cs
+++ b/Trady.Analysis/Extension/TuplesExtension.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Trady.Analysis.Indicator;
 using Trady.Analysis.Infrastructure;
 using Trady.Core.Infrastructure;
 
-namespace Trady.Analysis
+namespace Trady.Analysis.Extension
 {
     public static class TuplesExtension
     {

--- a/Trady.Analysis/Extension/TypeExtension.cs
+++ b/Trady.Analysis/Extension/TypeExtension.cs
@@ -1,9 +1,8 @@
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Trady.Analysis
+namespace Trady.Analysis.Extension
 {
     internal static class TypeExtension
     {

--- a/Trady.Analysis/IndexedCandle.cs
+++ b/Trady.Analysis/IndexedCandle.cs
@@ -7,9 +7,11 @@ using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis
 {
-    public class IndexedCandle : Candle, IIndexedObject<IOhlcvData>
+    public class IndexedCandle : Candle, IIndexedOhlcvData
     {
         private IAnalyzeContext _context;
+
+        private IIndexedOhlcvData _underlying;
 
         public IndexedCandle(IEnumerable<IOhlcvData> candles, int index)
             : base(candles.ElementAt(index).DateTime,
@@ -25,20 +27,24 @@ namespace Trady.Analysis
 
         public IEnumerable<IOhlcvData> BackingList { get; }
 
+        IIndexedOhlcvData IIndexedOhlcvData.Prev => Prev;
+
+        IIndexedOhlcvData IIndexedOhlcvData.Next => Next;
+
+        IIndexedOhlcvData IIndexedOhlcvData.Underlying => _underlying;
+
         public int Index { get; }
 
-        public IndexedCandle Prev => Index - 1 >= 0 ? new IndexedCandle(BackingList, Index - 1) : null;
+        public IIndexedOhlcvData Prev => Index - 1 >= 0 ? new IndexedCandle(BackingList, Index - 1) : null;
 
-        public IndexedCandle Next => Index + 1 < BackingList.Count() ? new IndexedCandle(BackingList, Index + 1) : null;
+        public IIndexedOhlcvData Next => Index + 1 < BackingList.Count() ? new IndexedCandle(BackingList, Index + 1) : null;
 
         public IOhlcvData Underlying => BackingList.ElementAt(Index);
 
         public IAnalyzeContext<IOhlcvData> Context
         {
             get => (IAnalyzeContext<IOhlcvData>)_context;
-            set {
-                _context = value;
-            }
+            set => _context = value;
         }
 
         IEnumerable IIndexedObject.BackingList => BackingList;
@@ -56,9 +62,7 @@ namespace Trady.Analysis
         IAnalyzeContext IIndexedObject.Context
         {
             get => _context;
-            set {
-                _context = value;
-            }
+            set => _context = value;
         }
 
         public TAnalyzable Get<TAnalyzable>(params object[] @params) where TAnalyzable : IAnalyzable

--- a/Trady.Analysis/IndexedCandle.cs
+++ b/Trady.Analysis/IndexedCandle.cs
@@ -7,11 +7,11 @@ using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis
 {
-    public class IndexedCandle : Candle, IIndexedObject<Candle>
+    public class IndexedCandle : Candle, IIndexedObject<IOhlcvData>
     {
         private IAnalyzeContext _context;
 
-        public IndexedCandle(IEnumerable<Candle> candles, int index)
+        public IndexedCandle(IEnumerable<IOhlcvData> candles, int index)
             : base(candles.ElementAt(index).DateTime,
                    candles.ElementAt(index).Open,
                    candles.ElementAt(index).High,
@@ -23,7 +23,7 @@ namespace Trady.Analysis
             Index = index;
         }
 
-        public IEnumerable<Candle> BackingList { get; }
+        public IEnumerable<IOhlcvData> BackingList { get; }
 
         public int Index { get; }
 
@@ -31,11 +31,11 @@ namespace Trady.Analysis
 
         public IndexedCandle Next => Index + 1 < BackingList.Count() ? new IndexedCandle(BackingList, Index + 1) : null;
 
-        public Candle Underlying => BackingList.ElementAt(Index);
+        public IOhlcvData Underlying => BackingList.ElementAt(Index);
 
-        public IAnalyzeContext<Candle> Context
+        public IAnalyzeContext<IOhlcvData> Context
         {
-            get => (IAnalyzeContext<Candle>)_context;
+            get => (IAnalyzeContext<IOhlcvData>)_context;
             set {
                 _context = value;
             }
@@ -45,11 +45,11 @@ namespace Trady.Analysis
 
         IIndexedObject IIndexedObject.Prev => Prev;
 
-        IIndexedObject<Candle> IIndexedObject<Candle>.Prev => Prev;
+        IIndexedObject<IOhlcvData> IIndexedObject<IOhlcvData>.Prev => Prev;
 
         IIndexedObject IIndexedObject.Next => Next;
 
-        IIndexedObject<Candle> IIndexedObject<Candle>.Next => Next;
+        IIndexedObject<IOhlcvData> IIndexedObject<IOhlcvData>.Next => Next;
 
         object IIndexedObject.Underlying => Underlying;
 

--- a/Trady.Analysis/Indicator/AccumulationDistributionLine.cs
+++ b/Trady.Analysis/Indicator/AccumulationDistributionLine.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -40,9 +41,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class AccumulationDistributionLine : AccumulationDistributionLine<Candle, AnalyzableTick<decimal?>>
+    public class AccumulationDistributionLine : AccumulationDistributionLine<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public AccumulationDistributionLine(IEnumerable<Candle> inputs)
+        public AccumulationDistributionLine(IEnumerable<IOhlcvData> inputs)
             : base(inputs, c => (c.High, c.Low, c.Close, c.Volume))
         {
         }

--- a/Trady.Analysis/Indicator/Aroon.cs
+++ b/Trady.Analysis/Indicator/Aroon.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
+using Trady.Analysis.Extension;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -51,9 +54,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class Aroon : Aroon<Candle, AnalyzableTick<(decimal? Up, decimal? Down)>>
+    public class Aroon : Aroon<IOhlcvData, AnalyzableTick<(decimal? Up, decimal? Down)>>
     {
-        public Aroon(IEnumerable<Candle> inputs, int periodCount)
+        public Aroon(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => (i.High, i.Low), periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/AroonOscillator.cs
+++ b/Trady.Analysis/Indicator/AroonOscillator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -34,9 +35,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class AroonOscillator : AroonOscillator<Candle, AnalyzableTick<decimal?>>
+    public class AroonOscillator : AroonOscillator<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public AroonOscillator(IEnumerable<Candle> inputs, int periodCount)
+        public AroonOscillator(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => (i.High, i.Low), periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/AverageDirectionalIndex.cs
+++ b/Trady.Analysis/Indicator/AverageDirectionalIndex.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -38,9 +39,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class AverageDirectionalIndex : AverageDirectionalIndex<Candle, AnalyzableTick<decimal?>>
+    public class AverageDirectionalIndex : AverageDirectionalIndex<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public AverageDirectionalIndex(IEnumerable<Candle> inputs, int periodCount)
+        public AverageDirectionalIndex(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => (i.High, i.Low, i.Close), periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/AverageDirectionalIndexRating.cs
+++ b/Trady.Analysis/Indicator/AverageDirectionalIndexRating.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -35,9 +36,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class AverageDirectionalIndexRating : AverageDirectionalIndexRating<Candle, AnalyzableTick<decimal?>>
+    public class AverageDirectionalIndexRating : AverageDirectionalIndexRating<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public AverageDirectionalIndexRating(IEnumerable<Candle> inputs, int periodCount, int adxrPeriodCount)
+        public AverageDirectionalIndexRating(IEnumerable<IOhlcvData> inputs, int periodCount, int adxrPeriodCount)
             : base(inputs, i => (i.High, i.Low, i.Close), periodCount, adxrPeriodCount)
         {
         }

--- a/Trady.Analysis/Indicator/AverageTrueRange.cs
+++ b/Trady.Analysis/Indicator/AverageTrueRange.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -39,9 +40,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class AverageTrueRange : AverageTrueRange<Candle, AnalyzableTick<decimal?>>
+    public class AverageTrueRange : AverageTrueRange<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public AverageTrueRange(IEnumerable<Candle> inputs, int periodCount)
+        public AverageTrueRange(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => (i.High, i.Low, i.Close), periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/BollingerBandWidth.cs
+++ b/Trady.Analysis/Indicator/BollingerBandWidth.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -38,9 +39,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class BollingerBandWidth : BollingerBandWidth<Candle, AnalyzableTick<decimal?>>
+    public class BollingerBandWidth : BollingerBandWidth<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public BollingerBandWidth(IEnumerable<Candle> inputs, int periodCount, decimal sdCount)
+        public BollingerBandWidth(IEnumerable<IOhlcvData> inputs, int periodCount, decimal sdCount)
             : base(inputs, i => i.Close, periodCount, sdCount)
         {
         }

--- a/Trady.Analysis/Indicator/BollingerBands.cs
+++ b/Trady.Analysis/Indicator/BollingerBands.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -41,9 +42,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class BollingerBands : BollingerBands<Candle, AnalyzableTick<(decimal? LowerBand, decimal? MiddleBand, decimal? UpperBand)>>
+    public class BollingerBands : BollingerBands<IOhlcvData, AnalyzableTick<(decimal? LowerBand, decimal? MiddleBand, decimal? UpperBand)>>
     {
-        public BollingerBands(IEnumerable<Candle> inputs, int periodCount, decimal sdCount)
+        public BollingerBands(IEnumerable<IOhlcvData> inputs, int periodCount, decimal sdCount)
             : base(inputs, i => i.Close, periodCount, sdCount)
         {
         }

--- a/Trady.Analysis/Indicator/ChandelierExit.cs
+++ b/Trady.Analysis/Indicator/ChandelierExit.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -44,9 +45,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class ChandelierExit : ChandelierExit<Candle, AnalyzableTick<(decimal? Long, decimal? Short)>>
+    public class ChandelierExit : ChandelierExit<IOhlcvData, AnalyzableTick<(decimal? Long, decimal? Short)>>
     {
-        public ChandelierExit(IEnumerable<Candle> inputs, int periodCount, decimal atrCount)
+        public ChandelierExit(IEnumerable<IOhlcvData> inputs, int periodCount, decimal atrCount)
             : base(inputs, i => (i.High, i.Low, i.Close), periodCount, atrCount)
         {
         }

--- a/Trady.Analysis/Indicator/ClosePriceChange.cs
+++ b/Trady.Analysis/Indicator/ClosePriceChange.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
-	public class ClosePriceChange : Difference<Candle, AnalyzableTick<decimal?>>
+	public class ClosePriceChange : Difference<IOhlcvData, AnalyzableTick<decimal?>>
 	{
-        public ClosePriceChange(IEnumerable<Candle> inputs, int numberOfDays = 1)
+        public ClosePriceChange(IEnumerable<IOhlcvData> inputs, int numberOfDays = 1)
 			: base(inputs, i => i.Close, numberOfDays)
 		{
 		}

--- a/Trady.Analysis/Indicator/ClosePricePercentageChange.cs
+++ b/Trady.Analysis/Indicator/ClosePricePercentageChange.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
-    public class ClosePricePercentageChange : PercentageDifference<Candle, AnalyzableTick<decimal?>>
+    public class ClosePricePercentageChange : PercentageDifference<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public ClosePricePercentageChange(IEnumerable<Candle> inputs, int numberOfDays = 1)
+        public ClosePricePercentageChange(IEnumerable<IOhlcvData> inputs, int numberOfDays = 1)
             : base(inputs, i => i.Close, numberOfDays)
         {
         }

--- a/Trady.Analysis/Indicator/DirectionalMovementIndex.cs
+++ b/Trady.Analysis/Indicator/DirectionalMovementIndex.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -36,9 +37,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class DirectionalMovementIndex : DirectionalMovementIndex<Candle, AnalyzableTick<decimal?>>
+    public class DirectionalMovementIndex : DirectionalMovementIndex<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public DirectionalMovementIndex(IEnumerable<Candle> inputs, int periodCount)
+        public DirectionalMovementIndex(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => (i.High, i.Low, i.Close), periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/EfficiencyRatio.cs
+++ b/Trady.Analysis/Indicator/EfficiencyRatio.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -34,9 +35,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class EfficiencyRatio : EfficiencyRatio<Candle, AnalyzableTick<decimal?>>
+    public class EfficiencyRatio : EfficiencyRatio<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public EfficiencyRatio(IEnumerable<Candle> inputs, int periodCount)
+        public EfficiencyRatio(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => i.Close, periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/ExponentialMovingAverage.cs
+++ b/Trady.Analysis/Indicator/ExponentialMovingAverage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -38,9 +39,9 @@ namespace Trady.Analysis.Indicator
 		}
     }
 
-    public class ExponentialMovingAverage : ExponentialMovingAverage<Candle, AnalyzableTick<decimal?>>
+    public class ExponentialMovingAverage : ExponentialMovingAverage<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public ExponentialMovingAverage(IEnumerable<Candle> inputs, int periodCount)
+        public ExponentialMovingAverage(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => i.Close, periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/ExponentialMovingAverageOscillator.cs
+++ b/Trady.Analysis/Indicator/ExponentialMovingAverageOscillator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -35,9 +36,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class ExponentialMovingAverageOscillator : ExponentialMovingAverageOscillator<Candle, AnalyzableTick<decimal?>>
+    public class ExponentialMovingAverageOscillator : ExponentialMovingAverageOscillator<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public ExponentialMovingAverageOscillator(IEnumerable<Candle> inputs, int periodCount1, int periodCount2)
+        public ExponentialMovingAverageOscillator(IEnumerable<IOhlcvData> inputs, int periodCount1, int periodCount2)
             : base(inputs, i => i.Close, periodCount1, periodCount2)
         {
         }

--- a/Trady.Analysis/Indicator/FuncAnalyzable.cs
+++ b/Trady.Analysis/Indicator/FuncAnalyzable.cs
@@ -45,9 +45,9 @@ namespace Trady.Analysis.Indicator
 		}
     }
 
-    public class FuncAnalyzable : FuncAnalyzable<Candle, AnalyzableTick<decimal?>>
+    public class FuncAnalyzable : FuncAnalyzable<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public FuncAnalyzable(IEnumerable<Candle> inputs, params decimal[] parameters) : base(inputs, parameters)
+        public FuncAnalyzable(IEnumerable<IOhlcvData> inputs, params decimal[] parameters) : base(inputs, parameters)
         {
         }
     }

--- a/Trady.Analysis/Indicator/HighestClose.cs
+++ b/Trady.Analysis/Indicator/HighestClose.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
-    public class HighestClose : Highest<Candle, AnalyzableTick<decimal?>>
+    public class HighestClose : Highest<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public HighestClose(IEnumerable<Candle> inputs, int periodCount)
+        public HighestClose(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => i.Close, periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/HighestHigh.cs
+++ b/Trady.Analysis/Indicator/HighestHigh.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
-    public class HighestHigh : Highest<Candle, AnalyzableTick<decimal?>>
+    public class HighestHigh : Highest<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public HighestHigh(IEnumerable<Candle> inputs, int periodCount)
+        public HighestHigh(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => i.High, periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/HistoricalHighestClose.cs
+++ b/Trady.Analysis/Indicator/HistoricalHighestClose.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
-    public class HistoricalHighestClose : HistoricalHighest<Candle, AnalyzableTick<decimal?>>
+    public class HistoricalHighestClose : HistoricalHighest<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public HistoricalHighestClose(IEnumerable<Candle> inputs)
+        public HistoricalHighestClose(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => i.Close)
         {
         }

--- a/Trady.Analysis/Indicator/HistoricalHighestHigh.cs
+++ b/Trady.Analysis/Indicator/HistoricalHighestHigh.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
-    public class HistoricalHighestHigh : HistoricalHighest<Candle, AnalyzableTick<decimal?>>
+    public class HistoricalHighestHigh : HistoricalHighest<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public HistoricalHighestHigh(IEnumerable<Candle> inputs)
+        public HistoricalHighestHigh(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => i.High)
         {
         }

--- a/Trady.Analysis/Indicator/HistoricalLowestClose.cs
+++ b/Trady.Analysis/Indicator/HistoricalLowestClose.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
-    public class HistoricalLowestClose : HistoricalLowest<Candle, AnalyzableTick<decimal?>>
+    public class HistoricalLowestClose : HistoricalLowest<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public HistoricalLowestClose(IEnumerable<Candle> inputs)
+        public HistoricalLowestClose(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => i.Close)
         {
         }

--- a/Trady.Analysis/Indicator/HistoricalLowestLow.cs
+++ b/Trady.Analysis/Indicator/HistoricalLowestLow.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
-    public class HistoricalLowestLow : HistoricalLowest<Candle, AnalyzableTick<decimal?>>
+    public class HistoricalLowestLow : HistoricalLowest<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public HistoricalLowestLow(IEnumerable<Candle> inputs)
+        public HistoricalLowestLow(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => i.Low)
         {
         }

--- a/Trady.Analysis/Indicator/IchimokuCloud.cs
+++ b/Trady.Analysis/Indicator/IchimokuCloud.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -75,9 +76,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class IchimokuCloud : IchimokuCloud<Candle, AnalyzableTick<(decimal? ConversionLine, decimal? BaseLine, decimal? LeadingSpanA, decimal? LeadingSpanB, decimal? LaggingSpan)>>
+    public class IchimokuCloud : IchimokuCloud<IOhlcvData, AnalyzableTick<(decimal? ConversionLine, decimal? BaseLine, decimal? LeadingSpanA, decimal? LeadingSpanB, decimal? LaggingSpan)>>
     {
-        public IchimokuCloud(IEnumerable<Candle> inputs, int shortPeriodCount, int middlePeriodCount, int longPeriodCount)
+        public IchimokuCloud(IEnumerable<IOhlcvData> inputs, int shortPeriodCount, int middlePeriodCount, int longPeriodCount)
             : base(inputs, i => (i.High, i.Low, i.Close), shortPeriodCount, middlePeriodCount, longPeriodCount)
         {
         }

--- a/Trady.Analysis/Indicator/KaufmanAdaptiveMovingAverage.cs
+++ b/Trady.Analysis/Indicator/KaufmanAdaptiveMovingAverage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -50,9 +51,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class KaufmanAdaptiveMovingAverage : KaufmanAdaptiveMovingAverage<Candle, AnalyzableTick<decimal?>>
+    public class KaufmanAdaptiveMovingAverage : KaufmanAdaptiveMovingAverage<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public KaufmanAdaptiveMovingAverage(IEnumerable<Candle> inputs, int periodCount, int emaFastPeriodCount, int emaSlowPeriodCount)
+        public KaufmanAdaptiveMovingAverage(IEnumerable<IOhlcvData> inputs, int periodCount, int emaFastPeriodCount, int emaSlowPeriodCount)
             : base(inputs, i => i.Close, periodCount, emaFastPeriodCount, emaSlowPeriodCount)
         {
         }

--- a/Trady.Analysis/Indicator/LowestClose.cs
+++ b/Trady.Analysis/Indicator/LowestClose.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
-    public class LowestClose : Lowest<Candle, AnalyzableTick<decimal?>>
+    public class LowestClose : Lowest<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public LowestClose(IEnumerable<Candle> inputs, int periodCount)
+        public LowestClose(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => i.Close, periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/LowestLow.cs
+++ b/Trady.Analysis/Indicator/LowestLow.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
-    public class LowestLow : Lowest<Candle, AnalyzableTick<decimal?>>
+    public class LowestLow : Lowest<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public LowestLow(IEnumerable<Candle> inputs, int periodCount)
+        public LowestLow(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => i.Low, periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/Median.cs
+++ b/Trady.Analysis/Indicator/Median.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -34,9 +35,9 @@ namespace Trady.Analysis.Indicator
 		}
     }
 
-	public class Median : Median<Candle, AnalyzableTick<decimal?>>
+	public class Median : Median<IOhlcvData, AnalyzableTick<decimal?>>
 	{
-		public Median(IEnumerable<Candle> inputs, int periodCount)
+		public Median(IEnumerable<IOhlcvData> inputs, int periodCount)
 			: base(inputs, i => i.Close, periodCount)
 		{
 		}

--- a/Trady.Analysis/Indicator/MinusDirectionalIndicator.cs
+++ b/Trady.Analysis/Indicator/MinusDirectionalIndicator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -46,9 +47,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class MinusDirectionalIndicator : MinusDirectionalIndicator<Candle, AnalyzableTick<decimal?>>
+    public class MinusDirectionalIndicator : MinusDirectionalIndicator<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public MinusDirectionalIndicator(IEnumerable<Candle> inputs, int periodCount)
+        public MinusDirectionalIndicator(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => (i.High, i.Low, i.Close), periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/MinusDirectionalMovement.cs
+++ b/Trady.Analysis/Indicator/MinusDirectionalMovement.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -23,9 +24,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class MinusDirectionalMovement : MinusDirectionalMovement<Candle, AnalyzableTick<decimal?>>
+    public class MinusDirectionalMovement : MinusDirectionalMovement<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public MinusDirectionalMovement(IEnumerable<Candle> inputs)
+        public MinusDirectionalMovement(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => i.Low)
         {
         }

--- a/Trady.Analysis/Indicator/ModifiedMovingAverage.cs
+++ b/Trady.Analysis/Indicator/ModifiedMovingAverage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -38,9 +39,9 @@ namespace Trady.Analysis.Indicator
 		}
     }
 
-    public class ModifiedMovingAverage : ModifiedMovingAverage<Candle, AnalyzableTick<decimal?>>
+    public class ModifiedMovingAverage : ModifiedMovingAverage<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public ModifiedMovingAverage(IEnumerable<Candle> inputs, int periodCount)
+        public ModifiedMovingAverage(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => i.Close, periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/MovingAverageConvergenceDivergence.cs
+++ b/Trady.Analysis/Indicator/MovingAverageConvergenceDivergence.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -48,9 +49,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class MovingAverageConvergenceDivergence : MovingAverageConvergenceDivergence<Candle, AnalyzableTick<(decimal? MacdLine, decimal? SignalLine, decimal? MacdHistogram)>>
+    public class MovingAverageConvergenceDivergence : MovingAverageConvergenceDivergence<IOhlcvData, AnalyzableTick<(decimal? MacdLine, decimal? SignalLine, decimal? MacdHistogram)>>
     {
-        public MovingAverageConvergenceDivergence(IEnumerable<Candle> inputs, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
+        public MovingAverageConvergenceDivergence(IEnumerable<IOhlcvData> inputs, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
             : base(inputs, i => i.Close, emaPeriodCount1, emaPeriodCount2, demPeriodCount)
         {
         }

--- a/Trady.Analysis/Indicator/MovingAverageConvergenceDivergenceHistogram.cs
+++ b/Trady.Analysis/Indicator/MovingAverageConvergenceDivergenceHistogram.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -37,9 +38,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class MovingAverageConvergenceDivergenceHistogram : MovingAverageConvergenceDivergenceHistogram<Candle, AnalyzableTick<decimal?>>
+    public class MovingAverageConvergenceDivergenceHistogram : MovingAverageConvergenceDivergenceHistogram<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public MovingAverageConvergenceDivergenceHistogram(IEnumerable<Candle> inputs, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
+        public MovingAverageConvergenceDivergenceHistogram(IEnumerable<IOhlcvData> inputs, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
             : base(inputs, i => i.Close, emaPeriodCount1, emaPeriodCount2, demPeriodCount)
         {
         }

--- a/Trady.Analysis/Indicator/OnBalanceVolume.cs
+++ b/Trady.Analysis/Indicator/OnBalanceVolume.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -31,9 +32,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class OnBalanceVolume : OnBalanceVolume<Candle, AnalyzableTick<decimal?>>
+    public class OnBalanceVolume : OnBalanceVolume<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public OnBalanceVolume(IEnumerable<Candle> inputs)
+        public OnBalanceVolume(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.Close, i.Volume))
         {
         }

--- a/Trady.Analysis/Indicator/Percentile.cs
+++ b/Trady.Analysis/Indicator/Percentile.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -48,9 +49,9 @@ namespace Trady.Analysis.Indicator
 		}
     }
 
-	public class Percentile : Percentile<Candle, AnalyzableTick<decimal?>>
+	public class Percentile : Percentile<IOhlcvData, AnalyzableTick<decimal?>>
 	{
-		public Percentile(IEnumerable<Candle> inputs, int periodCount, decimal percent)
+		public Percentile(IEnumerable<IOhlcvData> inputs, int periodCount, decimal percent)
 			: base(inputs, i => i.Close, periodCount, percent)
 		{
 		}

--- a/Trady.Analysis/Indicator/PlusDirectionalIndicator.cs
+++ b/Trady.Analysis/Indicator/PlusDirectionalIndicator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -46,9 +47,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class PlusDirectionalIndicator : PlusDirectionalIndicator<Candle, AnalyzableTick<decimal?>>
+    public class PlusDirectionalIndicator : PlusDirectionalIndicator<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public PlusDirectionalIndicator(IEnumerable<Candle> inputs, int periodCount)
+        public PlusDirectionalIndicator(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => (i.High, i.Low, i.Close), periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/PlusDirectionalMovement.cs
+++ b/Trady.Analysis/Indicator/PlusDirectionalMovement.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -23,9 +24,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class PlusDirectionalMovement : PlusDirectionalMovement<Candle, AnalyzableTick<decimal?>>
+    public class PlusDirectionalMovement : PlusDirectionalMovement<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public PlusDirectionalMovement(IEnumerable<Candle> inputs)
+        public PlusDirectionalMovement(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => i.High)
         {
         }

--- a/Trady.Analysis/Indicator/RawStochasticsValue.cs
+++ b/Trady.Analysis/Indicator/RawStochasticsValue.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -37,9 +38,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class RawStochasticsValue : RawStochasticsValue<Candle, AnalyzableTick<decimal?>>
+    public class RawStochasticsValue : RawStochasticsValue<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public RawStochasticsValue(IEnumerable<Candle> inputs, int periodCount)
+        public RawStochasticsValue(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => (i.High, i.Low, i.Close), periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/RelativeStrength.cs
+++ b/Trady.Analysis/Indicator/RelativeStrength.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -50,9 +51,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class RelativeStrength : RelativeStrength<Candle, AnalyzableTick<decimal?>>
+    public class RelativeStrength : RelativeStrength<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public RelativeStrength(IEnumerable<Candle> inputs, int periodCount)
+        public RelativeStrength(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => i.Close, periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/RelativeStrengthIndex.cs
+++ b/Trady.Analysis/Indicator/RelativeStrengthIndex.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -30,9 +31,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class RelativeStrengthIndex : RelativeStrengthIndex<Candle, AnalyzableTick<decimal?>>
+    public class RelativeStrengthIndex : RelativeStrengthIndex<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public RelativeStrengthIndex(IEnumerable<Candle> inputs, int periodCount)
+        public RelativeStrengthIndex(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => i.Close, periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/SimpleMovingAverage.cs
+++ b/Trady.Analysis/Indicator/SimpleMovingAverage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -29,9 +30,9 @@ namespace Trady.Analysis.Indicator
 	        : this(values.Cast<decimal?>(), periodCount) { }
     }
 
-    public class SimpleMovingAverage : SimpleMovingAverage<Candle, AnalyzableTick<decimal?>>
+    public class SimpleMovingAverage : SimpleMovingAverage<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public SimpleMovingAverage(IEnumerable<Candle> inputs, int periodCount)
+        public SimpleMovingAverage(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => i.Close, periodCount) { }
     }
 }

--- a/Trady.Analysis/Indicator/SimpleMovingAverageOscillator.cs
+++ b/Trady.Analysis/Indicator/SimpleMovingAverageOscillator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -35,9 +36,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class SimpleMovingAverageOscillator : SimpleMovingAverageOscillator<Candle, AnalyzableTick<decimal?>>
+    public class SimpleMovingAverageOscillator : SimpleMovingAverageOscillator<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public SimpleMovingAverageOscillator(IEnumerable<Candle> inputs, int periodCount1, int periodCount2)
+        public SimpleMovingAverageOscillator(IEnumerable<IOhlcvData> inputs, int periodCount1, int periodCount2)
             : base(inputs, i => i.Close, periodCount1, periodCount2)
         {
         }

--- a/Trady.Analysis/Indicator/StandardDeviation.cs
+++ b/Trady.Analysis/Indicator/StandardDeviation.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -44,9 +45,9 @@ namespace Trady.Analysis.Indicator
 		}
     }
 
-    public class StandardDeviation : StandardDeviation<Candle, AnalyzableTick<decimal?>>
+    public class StandardDeviation : StandardDeviation<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public StandardDeviation(IEnumerable<Candle> inputs, int periodCount)
+        public StandardDeviation(IEnumerable<IOhlcvData> inputs, int periodCount)
             : base(inputs, i => i.Close, periodCount)
         {
         }

--- a/Trady.Analysis/Indicator/Stochastics.Fast.cs
+++ b/Trady.Analysis/Indicator/Stochastics.Fast.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -40,9 +41,9 @@ namespace Trady.Analysis.Indicator
             }
         }
 
-        public class Fast : Fast<Candle, AnalyzableTick<(decimal? K, decimal? D, decimal? J)>>
+        public class Fast : Fast<IOhlcvData, AnalyzableTick<(decimal? K, decimal? D, decimal? J)>>
         {
-            public Fast(IEnumerable<Candle> inputs, int periodCount, int smaPeriodCount)
+            public Fast(IEnumerable<IOhlcvData> inputs, int periodCount, int smaPeriodCount)
                 : base(inputs, i => (i.High, i.Low, i.Close), periodCount, smaPeriodCount)
             {
             }

--- a/Trady.Analysis/Indicator/Stochastics.Full.cs
+++ b/Trady.Analysis/Indicator/Stochastics.Full.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -43,9 +44,9 @@ namespace Trady.Analysis.Indicator
             }
         }
 
-        public class Full : Full<Candle, AnalyzableTick<(decimal? K, decimal? D, decimal? J)>>
+        public class Full : Full<IOhlcvData, AnalyzableTick<(decimal? K, decimal? D, decimal? J)>>
         {
-            public Full(IEnumerable<Candle> inputs, int periodCount, int smaPeriodCountK, int smaPeriodCountD)
+            public Full(IEnumerable<IOhlcvData> inputs, int periodCount, int smaPeriodCountK, int smaPeriodCountD)
                 : base(inputs, i => (i.High, i.Low, i.Close), periodCount, smaPeriodCountK, smaPeriodCountD)
             {
             }

--- a/Trady.Analysis/Indicator/Stochastics.Slow.cs
+++ b/Trady.Analysis/Indicator/Stochastics.Slow.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -36,9 +37,9 @@ namespace Trady.Analysis.Indicator
             }
         }
 
-        public class Slow : Slow<Candle, AnalyzableTick<(decimal? K, decimal? D, decimal? J)>>
+        public class Slow : Slow<IOhlcvData, AnalyzableTick<(decimal? K, decimal? D, decimal? J)>>
         {
-            public Slow(IEnumerable<Candle> inputs, int periodCount, int smaPeriodCountD)
+            public Slow(IEnumerable<IOhlcvData> inputs, int periodCount, int smaPeriodCountD)
                 : base(inputs, i => (i.High, i.Low, i.Close), periodCount, smaPeriodCountD)
             {
             }

--- a/Trady.Analysis/Indicator/StochasticsOscillator.Fast.cs
+++ b/Trady.Analysis/Indicator/StochasticsOscillator.Fast.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -35,9 +36,9 @@ namespace Trady.Analysis.Indicator
             }
         }
 
-        public class Fast : Fast<Candle, AnalyzableTick<decimal?>>
+        public class Fast : Fast<IOhlcvData, AnalyzableTick<decimal?>>
         {
-            public Fast(IEnumerable<Candle> inputs, int periodCount, int smaPeriodCount) 
+            public Fast(IEnumerable<IOhlcvData> inputs, int periodCount, int smaPeriodCount) 
                 : base(inputs, i => (i.High, i.Low, i.Close), periodCount, smaPeriodCount)
             {
             }

--- a/Trady.Analysis/Indicator/StochasticsOscillator.Full.cs
+++ b/Trady.Analysis/Indicator/StochasticsOscillator.Full.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -37,9 +38,9 @@ namespace Trady.Analysis.Indicator
             }
         }
 
-        public class Full : Full<Candle, AnalyzableTick<decimal?>>
+        public class Full : Full<IOhlcvData, AnalyzableTick<decimal?>>
         {
-            public Full(IEnumerable<Candle> inputs, int periodCount, int smaPeriodCountK, int smaPeriodCountD) 
+            public Full(IEnumerable<IOhlcvData> inputs, int periodCount, int smaPeriodCountK, int smaPeriodCountD) 
                 : base(inputs, i => (i.High, i.Low, i.Close), periodCount, smaPeriodCountK, smaPeriodCountD)
             {
             }

--- a/Trady.Analysis/Indicator/StochasticsOscillator.Slow.cs
+++ b/Trady.Analysis/Indicator/StochasticsOscillator.Slow.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -35,9 +36,9 @@ namespace Trady.Analysis.Indicator
             }
         }
 
-        public class Slow : Slow<Candle, AnalyzableTick<decimal?>>
+        public class Slow : Slow<IOhlcvData, AnalyzableTick<decimal?>>
         {
-            public Slow(IEnumerable<Candle> inputs, int periodCount, int smaPeriodCountD) 
+            public Slow(IEnumerable<IOhlcvData> inputs, int periodCount, int smaPeriodCountD) 
                 : base(inputs, i => (i.High, i.Low, i.Close), periodCount, smaPeriodCountD)
             {
             }

--- a/Trady.Analysis/Indicator/TrueRange.cs
+++ b/Trady.Analysis/Indicator/TrueRange.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Trady.Analysis.Infrastructure;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Indicator
 {
@@ -27,9 +28,9 @@ namespace Trady.Analysis.Indicator
         }
     }
 
-    public class TrueRange : TrueRange<Candle, AnalyzableTick<decimal?>>
+    public class TrueRange : TrueRange<IOhlcvData, AnalyzableTick<decimal?>>
     {
-        public TrueRange(IEnumerable<Candle> inputs)
+        public TrueRange(IEnumerable<IOhlcvData> inputs)
             : base(inputs, i => (i.High, i.Low, i.Close))
         {
         }

--- a/Trady.Analysis/Infrastructure/AnalyzableBase.cs
+++ b/Trady.Analysis/Infrastructure/AnalyzableBase.cs
@@ -18,21 +18,21 @@ namespace Trady.Analysis.Infrastructure
     /// </summary>
     public abstract class AnalyzableBase<TInput, TMappedInput, TOutputToMap, TOutput> : IAnalyzable<TOutput>
     {
-        private readonly bool _isTInputCandle, _isTOutputAnalyzableTick;
+        private readonly bool _isTInputIOhlcvData, _isTOutputAnalyzableTick;
 
         internal protected readonly IReadOnlyList<TMappedInput> _mappedInputs;
         readonly IReadOnlyList<DateTime> _mappedDateTimes;
 
         protected AnalyzableBase(IEnumerable<TInput> inputs, Func<TInput, TMappedInput> inputMapper)
         {
-            _isTInputCandle = typeof(TInput).Equals(typeof(Candle));
+            _isTInputIOhlcvData = typeof(TInput).Equals(typeof(IOhlcvData));
             _isTOutputAnalyzableTick = typeof(TOutput).Equals(typeof(AnalyzableTick<TOutputToMap>));
-            if (_isTInputCandle != _isTOutputAnalyzableTick)
+            if (_isTInputIOhlcvData != _isTOutputAnalyzableTick)
                 throw new ArgumentException("TInput, TOutput not matched!");
 
             _mappedInputs = inputs.Select(inputMapper).ToList();
-            if (_isTInputCandle)
-                _mappedDateTimes = inputs.Select(c => (c as Candle).DateTime).ToList();
+            if (_isTInputIOhlcvData)
+                _mappedDateTimes = inputs.Select(c => (c as IOhlcvData).DateTime).ToList();
 
             Cache = new ConcurrentDictionary<int, TOutputToMap>();
         }

--- a/Trady.Analysis/Infrastructure/AnalyzableFactory.cs
+++ b/Trady.Analysis/Infrastructure/AnalyzableFactory.cs
@@ -19,7 +19,7 @@ namespace Trady.Analysis.Infrastructure
                 .FirstOrDefault(c => typeof(IEnumerable<TInput>).IsAssignableFrom(c.GetParameters().First().ParameterType));
 
             if (ctor == null)
-                throw new TargetInvocationException("Can't find default constructor for instantiation, please make sure that the analyzable has a constructor with IEnumerable<Candle> as the first parameter",
+                throw new TargetInvocationException("Can't find default constructor for instantiation, please make sure that the analyzable has a constructor with IEnumerable<IOhlcvData> as the first parameter",
                     new ArgumentNullException(nameof(ctor)));
 
             var @params = new List<object>();
@@ -30,8 +30,8 @@ namespace Trady.Analysis.Infrastructure
             return (TAnalyzable)ctor.Invoke(@params.ToArray());
         }
 
-        public static TAnalyzable CreateAnalyzable<TAnalyzable>(IEnumerable<Candle> candles, params object[] parameters)
+        public static TAnalyzable CreateAnalyzable<TAnalyzable>(IEnumerable<IOhlcvData> candles, params object[] parameters)
             where TAnalyzable : IAnalyzable
-            => CreateAnalyzable<TAnalyzable, Candle>(candles, parameters);
+            => CreateAnalyzable<TAnalyzable, IOhlcvData>(candles, parameters);
     }
 }

--- a/Trady.Analysis/Infrastructure/FuncAnalyzableFactory.cs
+++ b/Trady.Analysis/Infrastructure/FuncAnalyzableFactory.cs
@@ -15,7 +15,7 @@ namespace Trady.Analysis.Infrastructure
             return new FuncAnalyzable<TInput, TOutput>(inputs, parameters).Init(func);
         }
 
-        public static IFuncAnalyzable<AnalyzableTick<decimal?>> CreateAnalyzable(string name, IEnumerable<Candle> candles, params decimal[] parameters)
-            => CreateAnalyzable<Candle, AnalyzableTick<decimal?>>(name, candles, parameters);
+        public static IFuncAnalyzable<AnalyzableTick<decimal?>> CreateAnalyzable(string name, IEnumerable<IOhlcvData> candles, params decimal[] parameters)
+            => CreateAnalyzable<IOhlcvData, AnalyzableTick<decimal?>>(name, candles, parameters);
 	}
 }

--- a/Trady.Analysis/Infrastructure/FuncRegistry.cs
+++ b/Trady.Analysis/Infrastructure/FuncRegistry.cs
@@ -46,11 +46,11 @@ namespace Trady.Analysis.Infrastructure
         public static bool Register<TInput>(string name, Expression<Func<IReadOnlyList<TInput>, int, IReadOnlyList<decimal>, IAnalyzeContext<TInput>, decimal?>> expr, bool @override = false)
             => _Register(name, expr.Compile(), @override);
 
-		public static bool Register(string name, Expression<Func<IReadOnlyList<Candle>, int, IReadOnlyList<decimal>, IAnalyzeContext<Candle>, decimal?>> expr, bool @override = false)
-			=> Register<Candle>(name, expr, @override);
+		public static bool Register(string name, Expression<Func<IReadOnlyList<IOhlcvData>, int, IReadOnlyList<decimal>, IAnalyzeContext<IOhlcvData>, decimal?>> expr, bool @override = false)
+			=> Register<IOhlcvData>(name, expr, @override);
 
 		public static bool Register(string name, string expression, bool @override = false)
-            => Register<Candle>(name, expression, @override);
+            => Register<IOhlcvData>(name, expression, @override);
 
         public static bool Register(string name, IFuncAnalyzable analyzable, bool @override = false)
             => _Register(name, analyzable.Func, @override);

--- a/Trady.Analysis/Infrastructure/RuleRegistry.cs
+++ b/Trady.Analysis/Infrastructure/RuleRegistry.cs
@@ -21,11 +21,11 @@ namespace Trady.Analysis.Infrastructure
 
         public class RuleGlobals
         {
-            public IndexedCandle ic;
+            public IIndexedOhlcvData ic;
             public IReadOnlyList<decimal> p;
         }
 
-        private static Func<IndexedCandle, IReadOnlyList<decimal>, bool> CreateRule(string expression)
+        private static Func<IIndexedOhlcvData, IReadOnlyList<decimal>, bool> CreateRule(string expression)
         {
             var @delegate = CSharpScript.Create<bool>(expression, options, typeof(RuleGlobals)).CreateDelegate();
             return (_ic, _p) => @delegate(new RuleGlobals { ic = _ic, p = _p }).Result;
@@ -41,7 +41,7 @@ namespace Trady.Analysis.Infrastructure
         public static bool Register(string name, string expression, bool @override = false)
             => _Register(name, CreateRule(expression), @override);
 
-        public static bool Register(string name, Expression<Func<IndexedCandle, IReadOnlyList<decimal> ,bool>> expr, bool @override = false)
+        public static bool Register(string name, Expression<Func<IIndexedOhlcvData, IReadOnlyList<decimal> ,bool>> expr, bool @override = false)
             => _Register(name, expr.Compile(), @override);
 
         public static bool Unregister(string name) => _ruleDict.TryRemove(name, out _);

--- a/Trady.Analysis/Rule.cs
+++ b/Trady.Analysis/Rule.cs
@@ -1,15 +1,17 @@
 ﻿using System;
 
+using Trady.Core.Infrastructure;
+
 namespace Trady.Analysis
 {
     public static class Rule
     {
-        public static Predicate<IndexedCandle> Create(Predicate<IndexedCandle> predicate) => predicate;
+        public static Predicate<IIndexedOhlcvData> Create(Predicate<IIndexedOhlcvData> predicate) => predicate;
 
-        public static Predicate<IndexedCandle> Or(this Predicate<IndexedCandle> predicate1, Predicate<IndexedCandle> predicate2)
+        public static Predicate<IIndexedOhlcvData> Or(this Predicate<IIndexedOhlcvData> predicate1, Predicate<IIndexedOhlcvData> predicate2)
             => ic => predicate1(ic) || predicate2(ic);
 
-        public static Predicate<IndexedCandle> And(this Predicate<IndexedCandle> predicate1, Predicate<IndexedCandle> predicate2)
+        public static Predicate<IIndexedOhlcvData> And(this Predicate<IIndexedOhlcvData> predicate1, Predicate<IIndexedOhlcvData> predicate2)
             => ic => predicate1(ic) && predicate2(ic);
     }
 }

--- a/Trady.Analysis/SimpleRuleExecutor.cs
+++ b/Trady.Analysis/SimpleRuleExecutor.cs
@@ -6,14 +6,14 @@ using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis
 {
-    public class SimpleRuleExecutor : RuleExecutorBase<IOhlcvData, IndexedCandle, IndexedCandle>
+    public class SimpleRuleExecutor : RuleExecutorBase<IOhlcvData, IIndexedOhlcvData, IIndexedOhlcvData>
     {
-        public SimpleRuleExecutor(IAnalyzeContext<IOhlcvData> context, Predicate<IndexedCandle> rule)
-            : base((l, i) => l, context, new Predicate<IndexedCandle>[] { rule })
+        public SimpleRuleExecutor(IAnalyzeContext<IOhlcvData> context, Predicate<IIndexedOhlcvData> rule)
+            : base((l, i) => l, context, new[] { rule })
         {
         }
 
-        public override Func<IEnumerable<IOhlcvData>, int, IndexedCandle> IndexedObjectConstructor
+        public override Func<IEnumerable<IOhlcvData>, int, IIndexedOhlcvData> IndexedObjectConstructor
             => (l, i) => new IndexedCandle(l, i);
     }
 }

--- a/Trady.Analysis/SimpleRuleExecutor.cs
+++ b/Trady.Analysis/SimpleRuleExecutor.cs
@@ -6,14 +6,14 @@ using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis
 {
-    public class SimpleRuleExecutor : RuleExecutorBase<Candle, IndexedCandle, IndexedCandle>
+    public class SimpleRuleExecutor : RuleExecutorBase<IOhlcvData, IndexedCandle, IndexedCandle>
     {
-        public SimpleRuleExecutor(IAnalyzeContext<Candle> context, Predicate<IndexedCandle> rule)
+        public SimpleRuleExecutor(IAnalyzeContext<IOhlcvData> context, Predicate<IndexedCandle> rule)
             : base((l, i) => l, context, new Predicate<IndexedCandle>[] { rule })
         {
         }
 
-        public override Func<IEnumerable<Candle>, int, IndexedCandle> IndexedObjectConstructor
+        public override Func<IEnumerable<IOhlcvData>, int, IndexedCandle> IndexedObjectConstructor
             => (l, i) => new IndexedCandle(l, i);
     }
 }

--- a/Trady.Core/Candle.cs
+++ b/Trady.Core/Candle.cs
@@ -3,7 +3,7 @@ using Trady.Core.Infrastructure;
 
 namespace Trady.Core
 {
-    public class Candle : ITick
+    public class Candle : IOhlcvData
     {
         public Candle(DateTime dateTime, decimal open, decimal high, decimal low, decimal close, decimal volume)
         {

--- a/Trady.Core/CandleExtension.cs
+++ b/Trady.Core/CandleExtension.cs
@@ -2,38 +2,39 @@
 using System.Collections.Generic;
 using System.Linq;
 using Trady.Core.Exception;
+using Trady.Core.Infrastructure;
 using Trady.Core.Period;
 
 namespace Trady.Core
 {
-    public static class CandleExtension
+    public static class IOhlcvDataExtension
     {
-        public static decimal GetUpperShadow(this Candle candle) => candle.Open < candle.Close ? candle.High - candle.Close : candle.High - candle.Open;
+        public static decimal GetUpperShadow(this IOhlcvData candle) => candle.Open < candle.Close ? candle.High - candle.Close : candle.High - candle.Open;
 
-        public static decimal GetLowerShadow(this Candle candle) => candle.Open < candle.Close ? candle.Open - candle.Low : candle.Close - candle.Low;
+        public static decimal GetLowerShadow(this IOhlcvData candle) => candle.Open < candle.Close ? candle.Open - candle.Low : candle.Close - candle.Low;
 
-        public static decimal GetBody(this Candle candle) => Math.Abs(candle.Open - candle.Close);
+        public static decimal GetBody(this IOhlcvData candle) => Math.Abs(candle.Open - candle.Close);
 
-        public static bool IsBull(this Candle candle) => candle.Open - candle.Close > 0;
+        public static bool IsBull(this IOhlcvData candle) => candle.Open - candle.Close > 0;
 
-        public static bool IsBear(this Candle candle) => candle.Open - candle.Close < 0;
+        public static bool IsBear(this IOhlcvData candle) => candle.Open - candle.Close < 0;
 
         #region candle list transformation
 
-        public static IReadOnlyList<Candle> Transform<TSourcePeriod, TTargetPeriod>(this IEnumerable<Candle> candles)
+        public static IReadOnlyList<IOhlcvData> Transform<TSourcePeriod, TTargetPeriod>(this IEnumerable<IOhlcvData> candles)
             where TSourcePeriod : IPeriod
             where TTargetPeriod : IPeriod
         {
             if (typeof(TSourcePeriod).Equals(typeof(TTargetPeriod)))
                 return candles.ToList();
 
-            if (!IsTimeframesValid<TSourcePeriod>(candles, out Candle err))
+            if (!IsTimeframesValid<TSourcePeriod>(candles, out IOhlcvData err))
                 throw new InvalidTimeframeException(err.DateTime);
 
             if (!IsTransformationValid<TSourcePeriod, TTargetPeriod>())
                 throw new InvalidTransformationException(typeof(TSourcePeriod), typeof(TTargetPeriod));
 
-            var outCandles = new List<Candle>();
+            var outIOhlcvDatas = new List<IOhlcvData>();
             var periodInstance = Activator.CreateInstance<TTargetPeriod>();
 
             DateTime startTime = candles.First().DateTime;
@@ -42,21 +43,21 @@ namespace Trady.Core
                 var nextStartTime = periodInstance.NextTimestamp(startTime);
                 if (periodInstance.IsTimestamp(startTime))
                 {
-                    var outCandle = ComputeCandle(candles, startTime, nextStartTime);
-                    if (outCandle != null)
-                        outCandles.Add(outCandle);
+                    var outIOhlcvData = ComputeIOhlcvData(candles, startTime, nextStartTime);
+                    if (outIOhlcvData != null)
+                        outIOhlcvDatas.Add(outIOhlcvData);
                 }
                 startTime = nextStartTime;
             }
 
-            return outCandles;
+            return outIOhlcvDatas;
         }
 
-        private static bool IsTimeframesValid<TPeriod>(IEnumerable<Candle> candles, out Candle err)
+        private static bool IsTimeframesValid<TPeriod>(IEnumerable<IOhlcvData> candles, out IOhlcvData err)
             where TPeriod : IPeriod
         {
             var periodInstance = Activator.CreateInstance<TPeriod>();
-            err = default(Candle);
+            err = default(IOhlcvData);
             for (int i = 0; i < candles.Count() - 1; i++)
             {
                 var candleEndTime = periodInstance.NextTimestamp(candles.ElementAt(i).DateTime);
@@ -90,7 +91,7 @@ namespace Trady.Core
             return true;
         }
 
-        private static Candle ComputeCandle(IEnumerable<Candle> candles, DateTime startTime, DateTime endTime)
+        private static IOhlcvData ComputeIOhlcvData(IEnumerable<IOhlcvData> candles, DateTime startTime, DateTime endTime)
         {
             var candle = candles.Where(c => c.DateTime >= startTime && c.DateTime < endTime);
             if (candle.Any())

--- a/Trady.Core/Infrastructure/IImporter.cs
+++ b/Trady.Core/Infrastructure/IImporter.cs
@@ -9,6 +9,6 @@ namespace Trady.Core.Infrastructure
     public interface IImporter
     {
         // startTime & endTime should be inclusive
-        Task<IReadOnlyList<Candle>> ImportAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, PeriodOption period = PeriodOption.Daily, CancellationToken token = default(CancellationToken));
+        Task<IReadOnlyList<IOhlcvData>> ImportAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, PeriodOption period = PeriodOption.Daily, CancellationToken token = default(CancellationToken));
     }
 }

--- a/Trady.Core/Infrastructure/IIndexedOhlcvData.cs
+++ b/Trady.Core/Infrastructure/IIndexedOhlcvData.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace Trady.Core.Infrastructure
+{
+    public interface IIndexedOhlcvData : IOhlcvData, IIndexedObject<IOhlcvData>
+    {
+        new IEnumerable<IOhlcvData> BackingList { get; }
+
+        new IIndexedOhlcvData Prev { get; }
+
+        new IIndexedOhlcvData Next { get; }
+
+        new IIndexedOhlcvData Underlying { get; }
+
+        new IAnalyzeContext<IOhlcvData> Context { get; set; }
+
+        TAnalyzable Get<TAnalyzable>(params object[] @params)
+            where TAnalyzable : IAnalyzable;
+    }
+}

--- a/Trady.Core/Infrastructure/IOhlcvData.cs
+++ b/Trady.Core/Infrastructure/IOhlcvData.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Trady.Core.Infrastructure
+{
+    public interface IOhlcvData : ITick
+    {
+        decimal Open { get; }
+
+        decimal High { get; }
+
+        decimal Low { get; }
+
+        decimal Close { get; }
+
+        decimal Volume { get; }
+    }
+}

--- a/Trady.Importer.Csv/CsvImporter.cs
+++ b/Trady.Importer.Csv/CsvImporter.cs
@@ -1,17 +1,19 @@
-﻿using CsvHelper;
-using CsvHelper.Configuration;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Trady.Core;
-using Trady.Core.Period;
-using Trady.Core.Infrastructure;
 
-namespace Trady.Importer
+using CsvHelper;
+using CsvHelper.Configuration;
+
+using Trady.Core;
+using Trady.Core.Infrastructure;
+using Trady.Core.Period;
+
+namespace Trady.Importer.Csv
 {
     public class CsvImporter : IImporter
     {
@@ -28,14 +30,14 @@ namespace Trady.Importer
             _culture = culture;
         }
 
-        public async Task<IReadOnlyList<Candle>> ImportAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, PeriodOption period = PeriodOption.Daily, CancellationToken token = default(CancellationToken))
+        public async Task<IReadOnlyList<IOhlcvData>> ImportAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, PeriodOption period = PeriodOption.Daily, CancellationToken token = default(CancellationToken))
             => await Task.Factory.StartNew(() =>
             {
                 using (var fs = File.OpenRead(_path))
                 using (var sr = new StreamReader(fs))
                 using (var csvReader = new CsvReader(sr, new CsvConfiguration() { CultureInfo = _culture }))
                 {
-                    var candles = new List<Candle>();
+                    var candles = new List<IOhlcvData>();
                     while (csvReader.Read())
                     {
                         var date = csvReader.GetField<DateTime>(0);
@@ -46,7 +48,7 @@ namespace Trady.Importer
                 }
             });
 
-        public Candle GetRecord(CsvReader csv)
+        public IOhlcvData GetRecord(CsvReader csv)
         {
             // By using GetField Methodo of the CSV Reader Culture Info set in the configuration is used
             return new Candle(

--- a/Trady.Importer.Google/GoogleFinanceImporter.cs
+++ b/Trady.Importer.Google/GoogleFinanceImporter.cs
@@ -1,14 +1,15 @@
-﻿using Nuba.Finance.Google;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Trady.Core;
-using Trady.Core.Period;
-using Trady.Core.Infrastructure;
 
-namespace Trady.Importer
+using Nuba.Finance.Google;
+
+using Trady.Core.Infrastructure;
+using Trady.Core.Period;
+
+namespace Trady.Importer.Google
 {
     public class GoogleFinanceImporter : IImporter
     {
@@ -29,7 +30,7 @@ namespace Trady.Importer
             {PeriodOption.Daily, Frequency.EveryDay}
         };
 
-        public async Task<IReadOnlyList<Core.Candle>> ImportAsync(string symbol, DateTime? startTime = default(DateTime?), DateTime? endTime = default(DateTime?), PeriodOption period = PeriodOption.Daily, CancellationToken token = default(CancellationToken))
+        public async Task<IReadOnlyList<IOhlcvData>> ImportAsync(string symbol, DateTime? startTime = default(DateTime?), DateTime? endTime = default(DateTime?), PeriodOption period = PeriodOption.Daily, CancellationToken token = default(CancellationToken))
         {
             if (!PeriodMap.TryGetValue(period, out int frequency))
                 throw new ArgumentException("This importer only supports second, minute, hourly & daily data");

--- a/Trady.Importer.Quandl/Helper.cs
+++ b/Trady.Importer.Quandl/Helper.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Globalization;
-using Trady.Core;
 
-namespace Trady.Importer.Helper
+using Trady.Core;
+using Trady.Core.Infrastructure;
+
+namespace Trady.Importer.Quandl
 {
     internal static class Helper
     {
@@ -16,7 +18,7 @@ namespace Trady.Importer.Helper
             return false;
         }
 
-        public static Candle CreateCandle(this object[] row)
+        public static IOhlcvData CreateIOhlcvData(this object[] row)
         {
             return new Candle(
                 Convert.ToDateTime(row[0], CultureInfo.InvariantCulture),

--- a/Trady.Importer.Quandl/QuandlImporter.cs
+++ b/Trady.Importer.Quandl/QuandlImporter.cs
@@ -1,15 +1,15 @@
-﻿using Quandl.NET;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Trady.Core;
-using Trady.Core.Period;
-using Trady.Importer.Helper;
-using Trady.Core.Infrastructure;
 
-namespace Trady.Importer
+using Quandl.NET;
+
+using Trady.Core.Infrastructure;
+using Trady.Core.Period;
+
+namespace Trady.Importer.Quandl
 {
     public class QuandlImporter : IImporter
     {
@@ -29,13 +29,13 @@ namespace Trady.Importer
             _databaseCode = databaseCode;
         }
 
-        public async Task<IReadOnlyList<Candle>> ImportAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, PeriodOption period = PeriodOption.Daily, CancellationToken token = default(CancellationToken))
+        public async Task<IReadOnlyList<IOhlcvData>> ImportAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, PeriodOption period = PeriodOption.Daily, CancellationToken token = default(CancellationToken))
         {
             if (period != PeriodOption.Daily && period != PeriodOption.Weekly && period != PeriodOption.Monthly)
                 throw new ArgumentException("This importer only supports daily, weekly & monthly data");
 
             var response = await _client.Timeseries.GetDataAsync(_databaseCode, symbol, startDate: startTime, endDate: endTime, token: token, collapse: PeriodMap[period]).ConfigureAwait(false);
-            return response.DatasetData.Data.Where(r => !r.IsNullOrWhitespace()).Select(r => r.CreateCandle()).OrderBy(c => c.DateTime).ToList();
+            return response.DatasetData.Data.Where(r => !r.IsNullOrWhitespace()).Select(r => r.CreateIOhlcvData()).OrderBy(c => c.DateTime).ToList();
         }
     }
 

--- a/Trady.Importer.Stooq/StooqImporter.cs
+++ b/Trady.Importer.Stooq/StooqImporter.cs
@@ -1,14 +1,15 @@
-using StooqApi;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Trady.Core;
-using Trady.Core.Period;
-using Trady.Core.Infrastructure;
 
-namespace Trady.Importer
+using StooqApi;
+
+using Trady.Core.Infrastructure;
+using Trady.Core.Period;
+
+namespace Trady.Importer.Stooq
 {
     public class StooqImporter : IImporter
     {
@@ -28,12 +29,12 @@ namespace Trady.Importer
         /// <param name="endTime">End time.</param>
         /// <param name="period">Period.</param>
         /// <param name="token">Token.</param>
-        public async Task<IReadOnlyList<Core.Candle>> ImportAsync(string symbol, DateTime? startTime = default(DateTime?), DateTime? endTime = default(DateTime?), PeriodOption period = PeriodOption.Daily, CancellationToken token = default(CancellationToken))
+        public async Task<IReadOnlyList<IOhlcvData>> ImportAsync(string symbol, DateTime? startTime = default(DateTime?), DateTime? endTime = default(DateTime?), PeriodOption period = PeriodOption.Daily, CancellationToken token = default(CancellationToken))
         {
             if (period != PeriodOption.Daily && period != PeriodOption.Monthly && period != PeriodOption.Weekly)
                 throw new ArgumentException("This importer only supports daily, weekly & monthly data");
 
-            var candles = await Stooq.GetHistoricalAsync(symbol, PeriodMap[period], startTime, endTime, SkipOption.None, false, token);
+            var candles = await StooqApi.Stooq.GetHistoricalAsync(symbol, PeriodMap[period], startTime, endTime, SkipOption.None, false, token);
             return candles.Select(c => new Core.Candle(c.DateTime, c.Open, c.High, c.Low, c.Close, c.Volume)).OrderBy(c => c.DateTime).ToList();
         }
     }

--- a/Trady.Importer.Yahoo/YahooFinanceImporter.cs
+++ b/Trady.Importer.Yahoo/YahooFinanceImporter.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Trady.Core;
+
 using Trady.Core.Infrastructure;
 using Trady.Core.Period;
+
 using YahooFinanceApi;
 
-namespace Trady.Importer
+namespace Trady.Importer.Yahoo
 {
     public class YahooFinanceImporter : IImporter
     {
@@ -31,14 +32,14 @@ namespace Trady.Importer
         /// <param name="endTime">End time.</param>
         /// <param name="period">Period.</param>
         /// <param name="token">Token.</param>
-        public async Task<IReadOnlyList<Core.Candle>> ImportAsync(string symbol, DateTime? startTime = default(DateTime?), DateTime? endTime = default(DateTime?), PeriodOption period = PeriodOption.Daily, CancellationToken token = default(CancellationToken))
+        public async Task<IReadOnlyList<IOhlcvData>> ImportAsync(string symbol, DateTime? startTime = default(DateTime?), DateTime? endTime = default(DateTime?), PeriodOption period = PeriodOption.Daily, CancellationToken token = default(CancellationToken))
         {
             if (period != PeriodOption.Daily && period != PeriodOption.Weekly && period != PeriodOption.Monthly)
                 throw new ArgumentException("This importer only supports daily, weekly & monthly data");
 
             var corrStartTime = (startTime < UnixMinDateTime ? UnixMinDateTime : startTime) ?? UnixMinDateTime;
             var corrEndTime = AddPeriod((endTime > UnixMaxDateTime ? UnixMaxDateTime : endTime) ?? UnixMaxDateTime, period);
-            var candles = await Yahoo.GetHistoricalAsync(symbol, corrStartTime, corrEndTime, PeriodMap[period], false, false, token);
+            var candles = await YahooFinanceApi.Yahoo.GetHistoricalAsync(symbol, corrStartTime, corrEndTime, PeriodMap[period], false, false, token);
 
             return candles.Select(c => new Core.Candle(c.DateTime, c.Open, c.High, c.Low, c.Close, c.Volume)).OrderBy(c => c.DateTime).ToList();
         }

--- a/Trady.Test/BacktestTest.cs
+++ b/Trady.Test/BacktestTest.cs
@@ -7,15 +7,18 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Trady.Analysis;
 using Trady.Analysis.Backtest;
+using Trady.Analysis.Extension;
 using Trady.Core;
+using Trady.Core.Infrastructure;
 using Trady.Importer;
+using Trady.Importer.Csv;
 
 namespace Trady.Test
 {
     [TestClass]
     public class BacktestTest
     {
-		public async Task<IEnumerable<Candle>> ImportCandlesAsync()
+		public async Task<IEnumerable<IOhlcvData>> ImportIOhlcvDatasAsync()
 		{
 			var csvImporter = new CsvImporter("fb.csv", new CultureInfo("en-US"));
 			return await csvImporter.ImportAsync("fb");
@@ -26,8 +29,8 @@ namespace Trady.Test
 		[TestMethod]
 		public async Task TestBacktestAsync()
 		{
-			var fullCandles = await ImportCandlesAsync();
-			var candles = fullCandles.Where(c => c.DateTime < new DateTime(2013, 1, 1));
+			var fullIOhlcvDatas = await ImportIOhlcvDatasAsync();
+			var candles = fullIOhlcvDatas.Where(c => c.DateTime < new DateTime(2013, 1, 1));
 
 			var buyRule = Rule.Create(ic => ic.IsMacdBullishCross(12, 26, 9));
 			var sellRule = Rule.Create(ic => ic.IsMacdBearishCross(12, 26, 9));
@@ -65,12 +68,12 @@ namespace Trady.Test
 			Assert.IsTrue(result.TotalCorrectedProfitLossRatio == 0.022744817m);
 		}
 
-		private void Backtest_Onsold(IEnumerable<Candle> candles, int index, DateTime dateTime, decimal sellPrice, int quantity, decimal absCashFlow, decimal currentCashAmount, decimal plRatio)
+		private void Backtest_Onsold(IEnumerable<IOhlcvData> candles, int index, DateTime dateTime, decimal sellPrice, int quantity, decimal absCashFlow, decimal currentCashAmount, decimal plRatio)
 		{
 			File.AppendAllLines(logPath, new string[] { $"{index}({dateTime:yyyyMMdd}), Sell {candles.GetHashCode()}@{sellPrice} * {quantity}: {absCashFlow}, plRatio: {plRatio * 100:0.##}%, currentCashAmount: {currentCashAmount}" });
 		}
 
-		private void Backtest_OnBought(IEnumerable<Candle> candles, int index, DateTime dateTime, decimal buyPrice, int quantity, decimal absCashFlow, decimal currentCashAmount)
+		private void Backtest_OnBought(IEnumerable<IOhlcvData> candles, int index, DateTime dateTime, decimal buyPrice, int quantity, decimal absCashFlow, decimal currentCashAmount)
 		{
 			File.AppendAllLines(logPath, new string[] { $"{index}({dateTime:yyyyMMdd}), Buy {candles.GetHashCode()}@{buyPrice} * {quantity}: {absCashFlow}, currentCashAmount: {currentCashAmount}" });
 		}

--- a/Trady.Test/FuncTest.cs
+++ b/Trady.Test/FuncTest.cs
@@ -33,7 +33,7 @@ namespace Trady.Test
 
             RuleRegistry.Register("isbelowsma30_2", "ic.Get<SimpleMovingAverage>(30)[ic.Index].Tick.IsTrue(t => t > ic.Close)");
             RuleRegistry.Register("isbelowsma30", (ic, p) => ic.Get<SimpleMovingAverage>(p[0])[ic.Index].Tick.IsTrue(t => t > ic.Close));
-
+            
             using (var ctx = new AnalyzeContext(candles))
             {
                 var result = new SimpleRuleExecutor(ctx, ctx.GetRule("isbelowsma30_2")).Execute();

--- a/Trady.Test/ImporterTest.cs
+++ b/Trady.Test/ImporterTest.cs
@@ -3,6 +3,11 @@ using System;
 using System.Globalization;
 using System.Linq;
 using Trady.Importer;
+using Trady.Importer.Csv;
+using Trady.Importer.Google;
+using Trady.Importer.Quandl;
+using Trady.Importer.Stooq;
+using Trady.Importer.Yahoo;
 
 namespace Trady.Test
 {
@@ -72,8 +77,8 @@ namespace Trady.Test
             var importer = new CsvImporter("fb.csv", new CultureInfo("en-US"));
             var candles = importer.ImportAsync("FB").Result;
             Assert.AreEqual(candles.Count(), 1342);
-            var firstCandle = candles.First();
-            Assert.AreEqual(firstCandle.DateTime, new DateTime(2012, 5, 18));
+            var firstIOhlcvData = candles.First();
+            Assert.AreEqual(firstIOhlcvData.DateTime, new DateTime(2012, 5, 18));
         }
     }
 }

--- a/Trady.Test/IndicatorTest.cs
+++ b/Trady.Test/IndicatorTest.cs
@@ -7,13 +7,16 @@ using Trady.Core;
 using Trady.Importer;
 using System.Globalization;
 using Trady.Analysis;
+using Trady.Analysis.Extension;
+using Trady.Core.Infrastructure;
+using Trady.Importer.Csv;
 
 namespace Trady.Test
 {
     [TestClass]
     public class IndicatorTest
     {
-        protected async Task<IEnumerable<Candle>> ImportCandlesAsync()
+        protected async Task<IEnumerable<IOhlcvData>> ImportIOhlcvDatasAsync()
         {
             var csvImporter = new CsvImporter("fb.csv", new CultureInfo("en-US"));
             return await csvImporter.ImportAsync("fb");
@@ -26,7 +29,7 @@ namespace Trady.Test
 		[TestMethod]
 		public async Task TestMedianAsync()
 		{
-			var candles = await ImportCandlesAsync();
+			var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Median(10)[candles.Count() - 1];
 			Assert.IsTrue(171.8649975m.IsApproximatelyEquals(result.Tick.Value));
 		}
@@ -34,7 +37,7 @@ namespace Trady.Test
 		[TestMethod]
 		public async Task TestPercentileAsync()
 		{
-			var candles = await ImportCandlesAsync();
+			var candles = await ImportIOhlcvDatasAsync();
 			var result = candles.Percentile(30, 0.7m)[candles.Count() - 1];
 			Assert.IsTrue(171.3529969m.IsApproximatelyEquals(result.Tick.Value));
 
@@ -45,7 +48,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestSmaAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Sma(30)[candles.Count() - 1];
             Assert.IsTrue(170.15m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -53,7 +56,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestEmaAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Ema(30)[candles.Count() - 1];
             Assert.IsTrue(169.55m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -61,7 +64,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestAccumDistAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result0 = candles.AccumDist()[candles.Count() - 1];
             var result1 = candles.AccumDist()[candles.Count() - 2];
             var result2 = candles.AccumDist()[candles.Count() - 3];
@@ -71,7 +74,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestAroonAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Aroon(25)[candles.Count() - 1];
             Assert.IsTrue(84.0m.IsApproximatelyEquals(result.Tick.Up.Value));
             Assert.IsTrue(48.0m.IsApproximatelyEquals(result.Tick.Down.Value));
@@ -80,7 +83,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestAroonOscAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.AroonOsc(25)[candles.Count() - 1];
             Assert.IsTrue(36.0m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -88,7 +91,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestAtrAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Atr(14)[candles.Count() - 1];
             Assert.IsTrue(2.461m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -96,7 +99,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestBbAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Bb(20, 2)[candles.Count() - 1];
             Assert.IsTrue(166.15m.IsApproximatelyEquals(result.Tick.LowerBand.Value));
             Assert.IsTrue(170.42m.IsApproximatelyEquals(result.Tick.MiddleBand.Value));
@@ -106,7 +109,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestBbWidthAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.BbWidth(20, 2)[candles.Count() - 1];
             Assert.IsTrue(5.013m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -114,7 +117,7 @@ namespace Trady.Test
 		[TestMethod]
 		public async Task TestChandlrAsync()
 		{
-			var candles = await ImportCandlesAsync();
+			var candles = await ImportIOhlcvDatasAsync();
 			var result = candles.Chandlr(22, 3)[candles.Count() - 1];
 			Assert.IsTrue(166.47m.IsApproximatelyEquals(result.Tick.Long.Value));
 			Assert.IsTrue(172.53m.IsApproximatelyEquals(result.Tick.Short.Value));
@@ -123,7 +126,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestClosePriceChangeAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.CloseDiff()[candles.Count() - 1];
             Assert.IsTrue((-1.63m).IsApproximatelyEquals(result.Tick.Value));
 
@@ -134,7 +137,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestClosePricePercentageChangeAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.ClosePcDiff()[candles.Count() - 1];
             Assert.IsTrue((-0.949664419m).IsApproximatelyEquals(result.Tick.Value));
 
@@ -145,7 +148,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestPdiAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Pdi(14)[candles.Count() - 1];
             Assert.IsTrue(16.36m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -153,7 +156,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestMdiAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Mdi(14)[candles.Count() - 1];
             Assert.IsTrue(19.77m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -161,7 +164,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestAdxAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Adx(14)[candles.Count() - 1];
             Assert.IsTrue(15.45m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -169,7 +172,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestAdxrAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Adxr(14, 3)[candles.Count() - 1];
             Assert.IsTrue(16.21m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -177,7 +180,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestEfficiencyRatioAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Er(10)[candles.Count() - 1];
             Assert.IsTrue(0.147253482m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -185,7 +188,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestKamaAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Kama(10, 2, 30)[candles.Count() - 1];
             Assert.IsTrue(164.88m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -193,7 +196,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestEmaOscAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.EmaOsc(10, 30)[candles.Count() - 1];
             Assert.IsTrue(1.83m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -201,7 +204,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestHighestHighAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.HighHigh(10)[candles.Count() - 1];
             Assert.IsTrue(174m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -209,7 +212,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestHighestCloseAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.HighClose(10)[candles.Count() - 1];
             Assert.IsTrue(173.509995m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -217,7 +220,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestHistoricalHighestHighAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.HistHighHigh()[candles.Count() - 1];   
             Assert.IsTrue(175.490005m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -225,7 +228,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestHistoricalHighestCloseAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.HistHighClose()[candles.Count() - 1];
             Assert.IsTrue(173.509995m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -233,7 +236,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestLowestLowAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.LowLow(10)[candles.Count() - 1];
             Assert.IsTrue(169.339996m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -241,7 +244,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestLowestCloseAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.LowClose(10)[candles.Count() - 1];
             Assert.IsTrue(170.009995m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -249,7 +252,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestHistoricalLowestLowAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.HistLowLow()[candles.Count() - 1];
             Assert.IsTrue(17.549999m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -257,7 +260,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestHistoricalLowestCloseAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.HistLowClose()[candles.Count() - 1];
             Assert.IsTrue(17.73m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -265,7 +268,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestIchimokuCloudAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             int middlePeriodCount = 26;
             var results = candles.Ichimoku(9, middlePeriodCount, 52);
 
@@ -284,7 +287,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestMmaAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Mma(30)[candles.Count() - 1];
             Assert.IsTrue(169.9556615m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -292,7 +295,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestMacdAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Macd(12, 26, 9)[candles.Count() - 1];
             Assert.IsTrue(1.25m.IsApproximatelyEquals(result.Tick.MacdLine.Value));
             Assert.IsTrue(1.541m.IsApproximatelyEquals(result.Tick.SignalLine.Value));
@@ -302,7 +305,7 @@ namespace Trady.Test
 		[TestMethod]
 		public async Task TestMacdHistogramAsync()
 		{
-			var candles = await ImportCandlesAsync();
+			var candles = await ImportIOhlcvDatasAsync();
 			var result = candles.MacdHist(12, 26, 9)[candles.Count() - 1];
             Assert.IsTrue((-0.291m).IsApproximatelyEquals(result.Tick.Value));
 		}
@@ -310,7 +313,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestObvAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result0 = candles.Obv()[candles.Count() - 1];
             var result1 = candles.Obv()[candles.Count() - 2];
             var result2 = candles.Obv()[candles.Count() - 3];
@@ -320,7 +323,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestRsvAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Rsv(14)[candles.Count() - 1];
             Assert.IsTrue(55.66661111m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -328,7 +331,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestRsAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Rs(14)[candles.Count() - 1];
             Assert.IsTrue(1.011667673m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -336,7 +339,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestRsiAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Rsi(14)[candles.Count() - 1];
             Assert.IsTrue(50.29m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -344,7 +347,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestSmaOscAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.SmaOsc(10, 30)[candles.Count() - 1];
             Assert.IsTrue(1.76m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -352,7 +355,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestSdAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.Sd(10)[candles.Count() - 1];
             Assert.IsTrue(1.17m.IsApproximatelyEquals(result.Tick.Value));
         }
@@ -360,7 +363,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestFastStoAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.FastSto(14, 3)[candles.Count() - 1];
             Assert.IsTrue(55.67m.IsApproximatelyEquals(result.Tick.K.Value));
             Assert.IsTrue(65.22m.IsApproximatelyEquals(result.Tick.D.Value));
@@ -370,7 +373,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestSlowStoAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.SlowSto(14, 3)[candles.Count() - 1];
 			Assert.IsTrue(65.22m.IsApproximatelyEquals(result.Tick.K.Value));
 			Assert.IsTrue(74.36m.IsApproximatelyEquals(result.Tick.D.Value));
@@ -380,7 +383,7 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestFullStoAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var result = candles.FullSto(14, 3, 3)[candles.Count() - 1];
             Assert.IsTrue(65.22m.IsApproximatelyEquals(result.Tick.K.Value));
             Assert.IsTrue(74.36m.IsApproximatelyEquals(result.Tick.D.Value));
@@ -390,7 +393,7 @@ namespace Trady.Test
 		[TestMethod]
 		public async Task TestFastStoOscAsync()
 		{
-			var candles = await ImportCandlesAsync();
+			var candles = await ImportIOhlcvDatasAsync();
 			var result = candles.FastStoOsc(14, 3)[candles.Count() - 1];
             Assert.IsTrue((-9.55m).IsApproximatelyEquals(result.Tick.Value));
 		}
@@ -398,7 +401,7 @@ namespace Trady.Test
 		[TestMethod]
 		public async Task TestSlowStoOscAsync()
 		{
-			var candles = await ImportCandlesAsync();
+			var candles = await ImportIOhlcvDatasAsync();
 			var result = candles.SlowStoOsc(14, 3)[candles.Count() - 1];
 			Assert.IsTrue((-9.14m).IsApproximatelyEquals(result.Tick.Value));
 		}
@@ -406,7 +409,7 @@ namespace Trady.Test
 		[TestMethod]
 		public async Task TestFullStoOscAsync()
 		{
-			var candles = await ImportCandlesAsync();
+			var candles = await ImportIOhlcvDatasAsync();
 			var result = candles.FullStoOsc(14, 3, 3)[candles.Count() - 1];
 			Assert.IsTrue((-9.14m).IsApproximatelyEquals(result.Tick.Value));
 		}

--- a/Trady.Test/MiscallaneousTest.cs
+++ b/Trady.Test/MiscallaneousTest.cs
@@ -8,13 +8,16 @@ using Trady.Core;
 using Trady.Core.Period;
 using Trady.Importer;
 using Trady.Analysis;
+using Trady.Analysis.Extension;
+using Trady.Core.Infrastructure;
+using Trady.Importer.Csv;
 
 namespace Trady.Test
 {
     [TestClass]
     public class MiscallaneousTest
     {
-        public async Task<IEnumerable<Candle>> ImportCandlesAsync()
+        public async Task<IEnumerable<IOhlcvData>> ImportIOhlcvDatasAsync()
         {
             var csvImporter = new CsvImporter("fb.csv", new CultureInfo("en-US"));
             return await csvImporter.ImportAsync("fb");
@@ -23,9 +26,9 @@ namespace Trady.Test
 		[TestMethod]
         public async Task TestRuleExecutorAsync()
         {
-            var candles = await ImportCandlesAsync();
+            var candles = await ImportIOhlcvDatasAsync();
             var rule = Rule.Create(ic => ic.IsAboveSma(30));
-            IReadOnlyList<Candle> validObjects;
+            IReadOnlyList<IOhlcvData> validObjects;
             using (var ctx = new AnalyzeContext(candles))
                 validObjects = new SimpleRuleExecutor(ctx, rule).Execute();
             Assert.IsTrue(validObjects.Count() == 882);
@@ -34,14 +37,14 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestTransformationAsync()
         {
-            var candles = await ImportCandlesAsync();
-            var transCandles = candles.Transform<Daily, Weekly>();
-            var selectedCandle = transCandles.Where(c => c.DateTime.Equals(new DateTime(2017, 3, 13))).First();
-            Assert.IsTrue(138.71m.IsApproximatelyEquals(selectedCandle.Open));
-            Assert.IsTrue(140.34m.IsApproximatelyEquals(selectedCandle.High));
-            Assert.IsTrue(138.49m.IsApproximatelyEquals(selectedCandle.Low));
-            Assert.IsTrue(139.84m.IsApproximatelyEquals(selectedCandle.Close));
-            Assert.IsTrue((77.5m * 1000000).IsApproximatelyEquals(selectedCandle.Volume));
+            var candles = await ImportIOhlcvDatasAsync();
+            var transIOhlcvDatas = candles.Transform<Daily, Weekly>();
+            var selectedIOhlcvData = transIOhlcvDatas.Where(c => c.DateTime.Equals(new DateTime(2017, 3, 13))).First();
+            Assert.IsTrue(138.71m.IsApproximatelyEquals(selectedIOhlcvData.Open));
+            Assert.IsTrue(140.34m.IsApproximatelyEquals(selectedIOhlcvData.High));
+            Assert.IsTrue(138.49m.IsApproximatelyEquals(selectedIOhlcvData.Low));
+            Assert.IsTrue(139.84m.IsApproximatelyEquals(selectedIOhlcvData.Close));
+            Assert.IsTrue((77.5m * 1000000).IsApproximatelyEquals(selectedIOhlcvData.Volume));
         }
     }
 }


### PR DESCRIPTION
I created abstraction of Candle and IndexedCandle class using interfaces IOhlcvData and IIndexedOhlcvData. Mostly done using Resharper's refactoring techniques. The amount of changes is quite large, but consist mostly of substitution of specific class for interfaces.

What I am not so sure about two things:

1. Naming of the two new interfaces. Instead of IOhlcvData it could be just IOhlcv and IIndexedOhlcv respectively. 
2. Another shadowing in IIndexedOhlcvData. There already was shadowing using in generic version of IIndexedObject so I used it too to make it compatible with rest of the code. Would like to hear your ideas about it.

Fixes #10 