### PR TITLE
Care about fees

### DIFF
--- a/Trady.Analysis/Backtest/Builder.cs
+++ b/Trady.Analysis/Backtest/Builder.cs
@@ -1,42 +1,58 @@
 ﻿using System;
 using System.Collections.Generic;
-using Trady.Core;
 using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Backtest
 {
     public class Builder
     {
-        private IDictionary<IEnumerable<IOhlcv>, int> _weightings;
-        private Predicate<IIndexedOhlcv> _buyRule, _sellRule;
+        private readonly IDictionary<IEnumerable<IOhlcv>, int> _weightings;
+        private readonly Predicate<IIndexedOhlcv> _buyRule;
+        private readonly Predicate<IIndexedOhlcv> _sellRule;
+        private readonly decimal _fee;
+        private readonly bool _buyCompleteBaseCurrencies;
 
-        public Builder() : this(null, null, null)
+        public Builder() : this(null, null, null, 0, true)
         {
         }
 
         private Builder(
             IDictionary<IEnumerable<IOhlcv>, int> weightings, 
             Predicate<IIndexedOhlcv> buyRule, 
-            Predicate<IIndexedOhlcv> sellRule)
+            Predicate<IIndexedOhlcv> sellRule,
+            decimal fee,
+            bool buyCompleteBaseCurrencies)
         {
             _weightings = weightings ?? new Dictionary<IEnumerable<IOhlcv>, int>();
             _buyRule = buyRule;
             _sellRule = sellRule;
+            _fee = fee;
+            _buyCompleteBaseCurrencies = buyCompleteBaseCurrencies;
         }
 
         public Builder Add(IEnumerable<IOhlcv> candles, int weighting = 1)
         {
             _weightings.Add(candles, weighting);
-            return new Builder(_weightings, _buyRule, _sellRule);
+            return new Builder(_weightings, _buyRule, _sellRule, _fee, _buyCompleteBaseCurrencies);
         }
 
+        public Builder Fee(decimal fee)
+        {
+            return new Builder(_weightings, _buyRule, _sellRule, fee, _buyCompleteBaseCurrencies);
+        }
+
+        public Builder BuyPartialCurrencies()
+        {
+            return new Builder(_weightings, _buyRule, _sellRule, _fee, false);
+        }
+        
         public Builder Buy(Predicate<IIndexedOhlcv> rule)
-            => new Builder(_weightings, ic => _buyRule == null ? rule(ic) : rule(ic) || _buyRule(ic), _sellRule);
+            => new Builder(_weightings, ic => _buyRule == null ? rule(ic) : rule(ic) || _buyRule(ic), _sellRule, _fee, _buyCompleteBaseCurrencies);
 
         public Builder Sell(Predicate<IIndexedOhlcv> rule)
-            => new Builder(_weightings, _buyRule, ic => _sellRule  == null ? rule(ic) : rule(ic) || _sellRule(ic));
+            => new Builder(_weightings, _buyRule, ic => _sellRule  == null ? rule(ic) : rule(ic) || _sellRule(ic), _fee, _buyCompleteBaseCurrencies);
 
         public Runner Build()
-            => new Runner(_weightings, _buyRule, _sellRule);
+            => new Runner(_weightings, _buyRule, _sellRule, _fee, _buyCompleteBaseCurrencies);
     }
 }

--- a/Trady.Analysis/Backtest/Result.cs
+++ b/Trady.Analysis/Backtest/Result.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Trady.Core;

--- a/Trady.Analysis/Backtest/Transaction.cs
+++ b/Trady.Analysis/Backtest/Transaction.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Trady.Core;
 using Trady.Core.Infrastructure;
@@ -7,7 +7,7 @@ namespace Trady.Analysis.Backtest
 {
     public class Transaction : IEquatable<Transaction>
     {
-        public Transaction(IEnumerable<IOhlcv> candles, int index, DateTimeOffset dateTime, TransactionType type, int quantity, decimal absCashFlow)
+        public Transaction(IEnumerable<IOhlcv> candles, int index, DateTimeOffset dateTime, TransactionType type, decimal quantity, decimal absCashFlow)
         {
             IOhlcvDatas = candles;
             Index = index;
@@ -25,11 +25,32 @@ namespace Trady.Analysis.Backtest
 
         public TransactionType Type { get; }
 
-        public int Quantity { get; }
+        public decimal Quantity { get; }
 
         public decimal AbsoluteCashFlow { get; }
 
         public bool Equals(Transaction other)
-            => IOhlcvDatas.Equals(other.IOhlcvDatas) && Index == other.Index && Type == other.Type && Quantity == other.Quantity && AbsoluteCashFlow == other.AbsoluteCashFlow;
+            => other != null
+               && IOhlcvDatas.Equals(other.IOhlcvDatas)
+               && DateTime == other.DateTime
+               && Index == other.Index
+               && Type == other.Type
+               && Quantity == other.Quantity
+               && AbsoluteCashFlow == other.AbsoluteCashFlow;
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Transaction);
+        }
+
+        public override int GetHashCode()
+        {
+            return Index.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return $"Idx: {Index}; Date: {DateTime:d} Type: {Type}; Quantity: {Quantity:N3}; AbsoluteCashFlow: {AbsoluteCashFlow:N3}";
+        }
     }
 }

--- a/Trady.Importer.Csv/CsvImportConfiguration.cs
+++ b/Trady.Importer.Csv/CsvImportConfiguration.cs
@@ -9,7 +9,8 @@ namespace Trady.Importer.Csv
     {
         public string Delimiter { get; set; } = ",";
         public string DateFormat { get; set; }
-        public CultureInfo Culture { get; set; }
+        public string Culture { get; set; }
         public bool HasHeaderRecord { get; set; } = true;
+        public CultureInfo CultureInfo => string.IsNullOrEmpty(Culture)? null: CultureInfo.GetCultureInfo(Culture);
     }
 }

--- a/Trady.Importer.Csv/CsvImporter.cs
+++ b/Trady.Importer.Csv/CsvImporter.cs
@@ -33,7 +33,7 @@ namespace Trady.Importer.Csv
             _culture = culture;
         }
 
-        public CsvImporter(string path, CsvImportConfiguration configuration): this(path, configuration.Culture)
+        public CsvImporter(string path, CsvImportConfiguration configuration): this(path, configuration.CultureInfo)
         {
             _format = configuration.DateFormat;
             _delimiter = configuration.Delimiter;

--- a/Trady.Test/BacktestTest.cs
+++ b/Trady.Test/BacktestTest.cs
@@ -20,7 +20,7 @@ namespace Trady.Test
     {
 		public async Task<IEnumerable<IOhlcv>> ImportIOhlcvDatasAsync()
 		{
-			var csvImporter = new CsvImporter("fb.csv", new CultureInfo("en-US"));
+			var csvImporter = new CsvImporter("fb.csv", CultureInfo.GetCultureInfo("en-US"));
 			return await csvImporter.ImportAsync("fb");
 		}
 

--- a/Trady.Test/BacktestTest.cs
+++ b/Trady.Test/BacktestTest.cs
@@ -8,9 +8,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Trady.Analysis;
 using Trady.Analysis.Backtest;
 using Trady.Analysis.Extension;
-using Trady.Core;
 using Trady.Core.Infrastructure;
-using Trady.Importer;
 using Trady.Importer.Csv;
 
 namespace Trady.Test
@@ -26,11 +24,19 @@ namespace Trady.Test
 
 		private const string logPath = "backtest.txt";
 
+        
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context)
+        {
+            var file = File.Create(logPath);
+            file.Dispose();
+        }
+        
 		[TestMethod]
 		public async Task TestBacktestAsync()
 		{
 			var fullIOhlcvDatas = await ImportIOhlcvDatasAsync();
-			var candles = fullIOhlcvDatas.Where(c => c.DateTime < new DateTime(2013, 1, 1));
+			var candles = fullIOhlcvDatas.Where(c => c.DateTime < new DateTime(2013, 1, 1)).ToList();
 
 			var buyRule = Rule.Create(ic => ic.IsMacdBullishCross(12, 26, 9));
 			var sellRule = Rule.Create(ic => ic.IsMacdBearishCross(12, 26, 9));
@@ -40,9 +46,6 @@ namespace Trady.Test
 				.Buy(buyRule)
 				.Sell(sellRule)
 				.Build();
-
-			var file = File.Create(logPath);
-			file.Dispose();
 
 			runner.OnBought += Backtest_OnBought;
 			runner.OnSold += Backtest_Onsold;
@@ -59,25 +62,104 @@ namespace Trady.Test
 				new Transaction(candles, 124, new DateTime(2012, 11, 15), TransactionType.Buy, 382, 8534.88m),
 				new Transaction(candles, 145, new DateTime(2012, 12, 17), TransactionType.Sell, 382, 10225.14m)
 			};
+            
+            CollectionAssert.AreEquivalent(expecteds, result.Transactions.ToList(), $"Actual collection :{Environment.NewLine}{ToString(result.Transactions)}");
+		    Assert.AreEqual(10000m, result.TotalPrincipal);
+		    Assert.AreEqual(10227.44817m, result.TotalCorrectedBalance);
+		    Assert.AreEqual(0.022744817m, result.TotalCorrectedProfitLossRatio);
+		}
+        
+        [TestMethod]
+        public async Task TestBacktestWithPartialBaseCurrenciesAsync()
+        {
+            var fullIOhlcvDatas = await ImportIOhlcvDatasAsync();
+            var candles = fullIOhlcvDatas.Where(c => c.DateTime < new DateTime(2013, 1, 1)).ToList();
 
-			foreach (var expected in expecteds)
+            var buyRule = Rule.Create(ic => ic.IsMacdBullishCross(12, 26, 9));
+            var sellRule = Rule.Create(ic => ic.IsMacdBearishCross(12, 26, 9));
+
+            var runner = new Builder()
+                .Add(candles)
+                .BuyPartialCurrencies()
+                .Buy(buyRule)
+                .Sell(sellRule)
+                .Build();
+
+            runner.OnBought += Backtest_OnBought;
+            runner.OnSold += Backtest_Onsold;
+
+            var result = runner.RunAsync(10000).Result;
+            var expecteds = new List<Transaction>
             {
-                Assert.IsTrue(result.Transactions.Any(t => t.Equals(expected)));
-            }
+                new Transaction(candles, 19, new DateTime(2012, 6, 15), TransactionType.Buy, 350.71904594878989828130480533m, 10000.000000000000000000000000m),
+                new Transaction(candles, 40, new DateTime(2012, 7, 17), TransactionType.Sell, 350.71904594878989828130480533m, 9987.478428621536303051560856m),
+                new Transaction(candles, 62, new DateTime(2012, 8, 16), TransactionType.Buy, 488.57524168523946271096370573m, 9987.478428621536303051560856m),
+                new Transaction(candles, 99, new DateTime(2012, 10, 9), TransactionType.Sell, 488.57524168523946271096370573m, 9961.048689386790959437087249m),
+                new Transaction(candles, 111, new DateTime(2012, 10, 25), TransactionType.Buy, 427.6534247201960600790479678m, 9961.048689386790959437087249m),
+                new Transaction(candles, 120, new DateTime(2012, 11, 9), TransactionType.Sell, 427.6534247201960600790479678m, 8534.961929761688638981737358m),
+                new Transaction(candles, 124, new DateTime(2012, 11, 15), TransactionType.Buy, 382.00366740204514946202942516m, 8534.961929761688638981737358m),
+                new Transaction(candles, 145, new DateTime(2012, 12, 17), TransactionType.Sell, 382.00366740204514946202942516m, 10225.238176352748651098527712m)
+            };
+            
+            CollectionAssert.AreEquivalent(expecteds, result.Transactions.ToList(), $"Actual collection :{Environment.NewLine}{ToString(result.Transactions)}");
+            Assert.AreEqual(10000m, result.TotalPrincipal);
+            Assert.AreEqual(10225.238176352748651098527712m, result.TotalCorrectedBalance);
+            Assert.AreEqual(0.0225238176352748651098527712m, result.TotalCorrectedProfitLossRatio);
+        }
 
-            Assert.IsTrue(result.TotalPrincipal == 10000m);
-			Assert.IsTrue(result.TotalCorrectedBalance == 10227.44817m);
-			Assert.IsTrue(result.TotalCorrectedProfitLossRatio == 0.022744817m);
+        [TestMethod]
+        public async Task TestBacktestWithFeesAsync()
+        {
+            var fullIOhlcvDatas = await ImportIOhlcvDatasAsync();
+            var candles = fullIOhlcvDatas.Where(c => c.DateTime < new DateTime(2013, 1, 1)).ToList();
+
+            var buyRule = Rule.Create(ic => ic.IsMacdBullishCross(12, 26, 9));
+            var sellRule = Rule.Create(ic => ic.IsMacdBearishCross(12, 26, 9));
+
+            var runner = new Builder()
+                .Add(candles)
+                .BuyPartialCurrencies()
+                .Fee(0.001m)
+                .Buy(buyRule)
+                .Sell(sellRule)
+                .Build();
+
+            runner.OnBought += Backtest_OnBought;
+            runner.OnSold += Backtest_Onsold;
+
+            var result = runner.RunAsync(10000).Result;
+            var expecteds = new List<Transaction>
+            {
+                new Transaction(candles, 19, new DateTime(2012, 6, 15), TransactionType.Buy, 350.36832690284110838302350052m, 10000.000000000000000000000000m),
+                new Transaction(candles, 40, new DateTime(2012, 7, 17), TransactionType.Sell, 350.36832690284110838302350052m, 9967.512460242721851981760786m),
+                new Transaction(candles, 62, new DateTime(2012, 8, 16), TransactionType.Buy, 487.11083467082409292102182506m, 9967.512460242721851981760786m),
+                new Transaction(candles, 99, new DateTime(2012, 10, 9), TransactionType.Sell, 487.11083467082409292102182506m, 9921.258242395441315251706550m),
+                new Transaction(candles, 111, new DateTime(2012, 10, 25), TransactionType.Buy, 425.51900208819423725814588172m, 9921.258242395441315251706550m),
+                new Transaction(candles, 120, new DateTime(2012, 11, 9), TransactionType.Sell, 425.51900208819423725814588172m, 8483.866497305193532590876186m),
+                new Transaction(candles, 124, new DateTime(2012, 11, 15), TransactionType.Buy, 379.33677846051424973403246687m, 8483.866497305193532590876186m),
+                new Transaction(candles, 145, new DateTime(2012, 12, 17), TransactionType.Sell, 379.33677846051424973403246687m, 10143.691713828578498914669089m)
+            };
+            
+            CollectionAssert.AreEquivalent(expecteds, result.Transactions.ToList(), $"Actual collection :{Environment.NewLine}{ToString(result.Transactions)}");
+            Assert.AreEqual(10000m, result.TotalPrincipal);
+            Assert.AreEqual(10143.691713828578498914669089m, result.TotalCorrectedBalance);
+            Assert.AreEqual(0.0143691713828578498914669089m, result.TotalCorrectedProfitLossRatio);
+        }
+
+        private string ToString(IEnumerable<Transaction> resultTransactions)
+        {
+            return string.Join(Environment.NewLine, resultTransactions.Select(t => $"                new Transaction(candles, {t.Index}, new DateTime({t.DateTime.Year}, {t.DateTime.Month}, {t.DateTime.Day}), TransactionType.{t.Type}, {t.Quantity}m, {t.AbsoluteCashFlow}m),"));
+            //return string.Join(Environment.NewLine, resultTransactions.Select(t => t.ToString()));
+        }
+
+        private void Backtest_Onsold(IEnumerable<IOhlcv> candles, int index, DateTimeOffset dateTime, decimal sellPrice, decimal quantity, decimal absCashFlow, decimal currentCashAmount, decimal plRatio)
+		{
+			File.AppendAllLines(logPath, new[] { $"{index}({dateTime:yyyyMMdd}), Sell {candles.GetHashCode()}@{sellPrice} * {quantity}: {absCashFlow}, plRatio: {plRatio * 100:0.##}%, currentCashAmount: {currentCashAmount}" });
 		}
 
-		private void Backtest_Onsold(IEnumerable<IOhlcv> candles, int index, DateTimeOffset dateTime, decimal sellPrice, int quantity, decimal absCashFlow, decimal currentCashAmount, decimal plRatio)
+		private void Backtest_OnBought(IEnumerable<IOhlcv> candles, int index, DateTimeOffset dateTime, decimal buyPrice, decimal quantity, decimal absCashFlow, decimal currentCashAmount)
 		{
-			File.AppendAllLines(logPath, new string[] { $"{index}({dateTime:yyyyMMdd}), Sell {candles.GetHashCode()}@{sellPrice} * {quantity}: {absCashFlow}, plRatio: {plRatio * 100:0.##}%, currentCashAmount: {currentCashAmount}" });
-		}
-
-		private void Backtest_OnBought(IEnumerable<IOhlcv> candles, int index, DateTimeOffset dateTime, decimal buyPrice, int quantity, decimal absCashFlow, decimal currentCashAmount)
-		{
-			File.AppendAllLines(logPath, new string[] { $"{index}({dateTime:yyyyMMdd}), Buy {candles.GetHashCode()}@{buyPrice} * {quantity}: {absCashFlow}, currentCashAmount: {currentCashAmount}" });
+			File.AppendAllLines(logPath, new[] { $"{index}({dateTime:yyyyMMdd}), Buy {candles.GetHashCode()}@{buyPrice} * {quantity}: {absCashFlow}, currentCashAmount: {currentCashAmount}" });
 		}
     }
 }

--- a/Trady.Test/CustomIndicatorTest.cs
+++ b/Trady.Test/CustomIndicatorTest.cs
@@ -17,7 +17,7 @@ namespace Trady.Test
     {
         private async Task<IEnumerable<IOhlcv>> ImportIOhlcvDatasAsync()
         {
-            var csvImporter = new CsvImporter("fb.csv", new CultureInfo("en-US"));
+            var csvImporter = new CsvImporter("fb.csv", CultureInfo.GetCultureInfo("en-US"));
             return await csvImporter.ImportAsync("fb");
         }
 

--- a/Trady.Test/FuncTest.cs
+++ b/Trady.Test/FuncTest.cs
@@ -23,7 +23,7 @@ namespace Trady.Test
     {
 		public async Task<IEnumerable<IOhlcv>> ImportIOhlcvDatasAsync()
 		{
-			var csvImporter = new CsvImporter("fb.csv", new CultureInfo("en-US"));
+			var csvImporter = new CsvImporter("fb.csv", CultureInfo.GetCultureInfo("en-US"));
 			return await csvImporter.ImportAsync("fb");
 		}
 

--- a/Trady.Test/ImporterTest.cs
+++ b/Trady.Test/ImporterTest.cs
@@ -74,7 +74,7 @@ namespace Trady.Test
         [TestMethod]
         public void ImportFromCsv()
         {
-            var importer = new CsvImporter("fb.csv", new CultureInfo("en-US"));
+            var importer = new CsvImporter("fb.csv", CultureInfo.GetCultureInfo("en-US"));
             var candles = importer.ImportAsync("FB").Result;
             Assert.AreEqual(candles.Count, 1342);
             var firstIOhlcvData = candles.First();
@@ -86,7 +86,7 @@ namespace Trady.Test
         {
             var config = new CsvImportConfiguration()
             {
-                Culture = new CultureInfo("en-US"),
+                Culture = "en-US",
                 Delimiter = ";",
                 DateFormat = "yyyyMMdd HHmmss",
                 HasHeaderRecord = false

--- a/Trady.Test/IndexedCandleTest.cs
+++ b/Trady.Test/IndexedCandleTest.cs
@@ -18,7 +18,7 @@ namespace Trady.Test
     {
         protected async Task<IEnumerable<IOhlcv>> ImportCandlesAsync()
         {
-            var csvImporter = new CsvImporter("fb.csv", new CultureInfo("en-US"));
+            var csvImporter = new CsvImporter("fb.csv", CultureInfo.GetCultureInfo("en-US"));
             return await csvImporter.ImportAsync("fb");
         }
 

--- a/Trady.Test/IndicatorTest.cs
+++ b/Trady.Test/IndicatorTest.cs
@@ -20,7 +20,8 @@ namespace Trady.Test
         protected async Task<IEnumerable<IOhlcv>> ImportIOhlcvDatasAsync()
         {
             // Last record: 09/18/2017
-            var csvImporter = new CsvImporter("fb.csv", new CultureInfo("en-US"));
+            var csvImporter = new CsvImporter("fb.csv", CultureInfo.GetCultureInfo("en-US"));
+
             return await csvImporter.ImportAsync("fb");
             //var yahooImporter = new YahooFinanceImporter();
             //var candles = await yahooImporter.ImportAsync("FB");

--- a/Trady.Test/MiscallaneousTest.cs
+++ b/Trady.Test/MiscallaneousTest.cs
@@ -19,7 +19,7 @@ namespace Trady.Test
     {
         public async Task<IEnumerable<IOhlcv>> ImportIOhlcvDatasAsync()
         {
-            var csvImporter = new CsvImporter("fb.csv", new CultureInfo("en-US"));
+            var csvImporter = new CsvImporter("fb.csv", CultureInfo.GetCultureInfo("en-US"));
             return await csvImporter.ImportAsync("fb");
         }
 


### PR DESCRIPTION
**Fix local aspect in unit tests**  …
For an obscure reason, the cultureinfo constructor does not build the culture with expected culture settings.
On a counter pater, it looks like the GetCultureInfo really reflects the expected culture parameters (like date format).


**Add fee support + partial buy**  …
**Fee** : The test TestBacktestWithFeesAsync illustrates how you can declare a flat fee
that will be applied on any transaction. In this sample we the target currency is alway reduced by 0.1%

**Partial buy** :
- by default, the runner will continue to buy complete base currencies only
- if specified, the runner will buy base currency with all available quote currency (cash)