### PR TITLE
Refactored buy/sell calculation to allow for broker fee implementations

### DIFF
--- a/Trady.Analysis/Backtest/Builder.cs
+++ b/Trady.Analysis/Backtest/Builder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Trady.Analysis.Backtest.FeeCalculators;
 using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Backtest
@@ -9,11 +10,10 @@ namespace Trady.Analysis.Backtest
         private readonly IDictionary<IEnumerable<IOhlcv>, int> _weightings;
         private readonly Predicate<IIndexedOhlcv> _buyRule;
         private readonly Predicate<IIndexedOhlcv> _sellRule;
-        private readonly decimal _flatExchangeFee;
         private readonly bool _buyInCompleteQuantity;
-        private readonly decimal _premium;
+        private readonly IFeeCalculator _calculator;
 
-        public Builder() : this(null, null, null, 0, true, 1)
+        public Builder() : this(null, null, null, true, null)
         {
         }
 
@@ -21,40 +21,63 @@ namespace Trady.Analysis.Backtest
             IDictionary<IEnumerable<IOhlcv>, int> weightings, 
             Predicate<IIndexedOhlcv> buyRule, 
             Predicate<IIndexedOhlcv> sellRule,
-            decimal flatExchangeFee,
             bool buyInCompleteQuantity,
-            decimal premium)
+            IFeeCalculator calculator)
         {
             _weightings = weightings ?? new Dictionary<IEnumerable<IOhlcv>, int>();
             _buyRule = buyRule;
             _sellRule = sellRule;
-            _flatExchangeFee = flatExchangeFee;
             _buyInCompleteQuantity = buyInCompleteQuantity;
-            _premium = premium;
+
+            //Use default calculator if none defined.
+            _calculator = calculator ?? new FeeCalculator();
         }
 
         public Builder Add(IEnumerable<IOhlcv> candles, int weighting = 1)
         {
             _weightings.Add(candles, weighting);
-            return new Builder(_weightings, _buyRule, _sellRule, _flatExchangeFee, _buyInCompleteQuantity, _premium);
+            return new Builder(_weightings, _buyRule, _sellRule, _buyInCompleteQuantity, _calculator);
         }
 
         public Builder FlatExchangeFeeRate(decimal flatExchangeFeeRate)
-            => new Builder(_weightings, _buyRule, _sellRule, flatExchangeFeeRate, _buyInCompleteQuantity, _premium);
+        {
+            var calculator = new FeeCalculator(flatExchangeFeeRate, 1);
+            return new Builder(_weightings, _buyRule, _sellRule, _buyInCompleteQuantity, calculator);
+        }
+
+        public Builder Calculator(IFeeCalculator calculator)
+            => new Builder(_weightings, _buyRule, _sellRule, _buyInCompleteQuantity, calculator);
+        
 
         public Builder BuyWithAllAvailableCash()
-            => new Builder(_weightings, _buyRule, _sellRule, _flatExchangeFee, false, _premium);
+            => new Builder(_weightings, _buyRule, _sellRule, false, _calculator);
         
         public Builder Buy(Predicate<IIndexedOhlcv> rule)
-            => new Builder(_weightings, ic => _buyRule == null ? rule(ic) : rule(ic) || _buyRule(ic), _sellRule, _flatExchangeFee, _buyInCompleteQuantity, _premium);
+            => new Builder(_weightings, ic => _buyRule == null ? rule(ic) : rule(ic) || _buyRule(ic), _sellRule, _buyInCompleteQuantity, _calculator);
 
         public Builder Sell(Predicate<IIndexedOhlcv> rule)
-            => new Builder(_weightings, _buyRule, ic => _sellRule  == null ? rule(ic) : rule(ic) || _sellRule(ic), _flatExchangeFee, _buyInCompleteQuantity, _premium);
+            => new Builder(_weightings, _buyRule, ic => _sellRule  == null ? rule(ic) : rule(ic) || _sellRule(ic), _buyInCompleteQuantity, _calculator);
 
+        /// <summary>
+        /// The cost per trade/transaction.
+        /// </summary>
+        /// <param name="premium">A numerical value that represents the cost of each transaction.</param>
+        /// <returns></returns>
         public Builder Premium(decimal premium)
-            => new Builder(_weightings, _buyRule, _sellRule, _flatExchangeFee, _buyInCompleteQuantity, premium);
+        {
+            var calculator = new FeeCalculator(0, premium);
+            return new Builder(_weightings, _buyRule, _sellRule, _buyInCompleteQuantity, _calculator);
+        }
+
+        public Builder PremiumAndFees(decimal premium, decimal flatExchangeFeeRate)
+        {
+            var calculator = new FeeCalculator(flatExchangeFeeRate, premium);
+            return new Builder(_weightings, _buyRule, _sellRule, _buyInCompleteQuantity, _calculator);
+        }
+
 
         public Runner Build()
-            => new Runner(_weightings, _buyRule, _sellRule, _flatExchangeFee, _buyInCompleteQuantity, _premium);
+            => new Runner(_weightings, _buyRule, _sellRule, _buyInCompleteQuantity, _calculator);
+            
     }
 }

--- a/Trady.Analysis/Backtest/FeeCalculators/FeeCalculator.cs
+++ b/Trady.Analysis/Backtest/FeeCalculators/FeeCalculator.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Trady.Core.Infrastructure;
+
+namespace Trady.Analysis.Backtest.FeeCalculators
+{
+    /// <summary>
+    /// Base calculator for any rule.
+    /// </summary>
+    /// <remarks>
+    /// You can implement your own calculator for any particular broker's rules.
+    /// For example: some brokers charge differently for larger orders...  You can implement that logic in in your own IAssetCalculator
+    /// </remarks>
+    public class FeeCalculator : IFeeCalculator
+    {
+        public FeeCalculator() : this(0, 1)
+        {
+
+        }
+        public FeeCalculator(decimal flatExchangeFee, decimal premium, int roundingDecimals = -1)
+        {
+            FlatExchangeFee = flatExchangeFee;
+            Premium = premium;
+            if(roundingDecimals != -1)
+            {
+                RoundingDecimals = roundingDecimals;
+            }
+        }
+
+        protected decimal FlatExchangeFee { get; private set; }
+        protected decimal Premium { get; private set; }
+        protected int RoundingDecimals { get; private set; }
+
+        public Transaction BuyAsset(IIndexedOhlcv indexedCandle, decimal cash, IIndexedOhlcv nextCandle, bool buyInCompleteQuantities)
+        {
+            decimal quantity = (cash - Premium) / nextCandle.Open;
+            if(buyInCompleteQuantities)
+                quantity = Math.Floor(quantity);
+
+            decimal cashToBuyAsset = nextCandle.Open * quantity + Premium;
+
+            var costs = RoundingDecimals != -1
+                ? Math.Round(Premium + (FlatExchangeFee * quantity), RoundingDecimals)
+                : Premium + (FlatExchangeFee * quantity);
+
+            // EUR/USD (1€ = 1000$) ; flat exchange fee ratio percent = 0.1
+            // you buy 2000$
+            // Total 2€, fee = 2 * 0.001 = 0.002, net = 2 - 0.002 = 1.998 €
+            quantity -= FlatExchangeFee * quantity;
+            //var quoteCurrencyFee = _flatExchangeFee * nextCandle.Open;
+
+            return new Transaction(indexedCandle.BackingList, nextCandle.Index, nextCandle.DateTime, TransactionType.Buy, quantity, cashToBuyAsset, costs);
+        }
+
+       
+
+        public Transaction SellAsset(IIndexedOhlcv indexedCandle, Transaction lastTransaction)
+        {            
+            var nextCandle = indexedCandle.Next;
+            
+            decimal quantity = lastTransaction.Quantity;
+            decimal cashWhenSellAsset = nextCandle.Open * quantity - Premium;
+
+            // EUR/USD (1€ = 1000$) ; flat exchange fee ratio percent = 0.1
+            // you sell 1.999€
+            // Total 1999€, fee = 1.999, net = 1997.001 €
+            var costs = RoundingDecimals != -1
+                ? Math.Round(Premium + (FlatExchangeFee * cashWhenSellAsset), RoundingDecimals)
+                : Premium + (FlatExchangeFee * cashWhenSellAsset);
+
+            cashWhenSellAsset -= FlatExchangeFee * cashWhenSellAsset;         
+
+            return new Transaction(indexedCandle.BackingList, nextCandle.Index, nextCandle.DateTime, TransactionType.Sell, quantity, cashWhenSellAsset, costs);
+        }
+    }
+}

--- a/Trady.Analysis/Backtest/FeeCalculators/IFeeCalculator.cs
+++ b/Trady.Analysis/Backtest/FeeCalculators/IFeeCalculator.cs
@@ -1,0 +1,17 @@
+﻿using Trady.Core.Infrastructure;
+
+namespace Trady.Analysis.Backtest.FeeCalculators
+{
+    /// <summary>
+    /// Interface to calculate buy/sell logic.
+    /// </summary>
+    /// <remarks>
+    /// You can implement your own calculator for any particular broker's rules.
+    /// For example: some brokers charge differently for larger orders...  You can implement that logic in in your own IAssetCalculator
+    /// </remarks>
+    public interface IFeeCalculator
+    {
+        Transaction BuyAsset(IIndexedOhlcv indexedCandle, decimal cash, IIndexedOhlcv nextCandle, bool buyInCompleteQuantities);
+        Transaction SellAsset(IIndexedOhlcv indexedCandle, Transaction lastTransaction);
+    }
+}

--- a/Trady.Analysis/Backtest/FeeCalculators/InteractiveBrokersFixedFeeCalculator.cs
+++ b/Trady.Analysis/Backtest/FeeCalculators/InteractiveBrokersFixedFeeCalculator.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Trady.Core.Infrastructure;
+
+namespace Trady.Analysis.Backtest.FeeCalculators
+{
+    public class InteractiveBrokersFixedFeeCalculator : IFeeCalculator
+    {
+        public InteractiveBrokersFixedFeeCalculator() : this(0.0075m, 1.0m, 1.0m, 0.0000130m, 0.000119m) { }
+
+        public InteractiveBrokersFixedFeeCalculator(decimal perShareFee, decimal minimumPerOrder, decimal maximumPerOrderPercent, decimal transactionFees, decimal fINRAFees, int roundingDecimals = 2)
+        {
+            PerShareFee = perShareFee;
+            MinimumPerOrder = minimumPerOrder;
+            MaximumPerOrderPercent = maximumPerOrderPercent;
+            RoundingDecimals = roundingDecimals;
+            TransactionFees = transactionFees;
+            FINRAFees = fINRAFees;
+        }
+
+        protected decimal PerShareFee { get; private set; }
+        protected decimal MinimumPerOrder { get; private set; }
+        protected decimal MaximumPerOrderPercent { get; private set; }
+        protected decimal TransactionFees { get; private set; }
+        protected decimal FINRAFees { get; private set; }
+        protected int RoundingDecimals { get; private set; }
+
+        public Transaction BuyAsset(IIndexedOhlcv indexedCandle, decimal cash, IIndexedOhlcv nextCandle, bool buyInCompleteQuantities)
+        {
+            //Interactive Brokers Pricing
+            //https://www.interactivebrokers.com/en/index.php?f=1590&p=stocks1
+
+            //determine initial quantity
+            decimal quantity = cash / nextCandle.Open;
+            var fee = DetermineFee(nextCandle, quantity);
+            quantity = (cash - quantity) / nextCandle.Open;
+
+            if(buyInCompleteQuantities)
+                quantity = Math.Floor(quantity);
+
+            //get fee after final determination of quantity is found.
+            var actualFee = DetermineFee(nextCandle, quantity);
+
+            var costs = RoundingDecimals != -1
+                ? Math.Round(actualFee, RoundingDecimals)
+                : actualFee;
+
+            decimal cashToBuyAsset = nextCandle.Open * quantity + costs;            
+
+            return new Transaction(indexedCandle.BackingList, nextCandle.Index, nextCandle.DateTime, TransactionType.Buy, quantity, cashToBuyAsset, costs);
+        }
+
+        private decimal DetermineFee(IIndexedOhlcv nextCandle, decimal quantity)
+        {
+            var cost = quantity * PerShareFee;
+            var tradePrice = quantity * nextCandle.Open;
+
+            if(cost < 1.0m)
+            {
+                cost = 1.0m;
+            }
+            else if(cost / tradePrice > .01m)
+            {
+                cost = tradePrice * .01m;
+            }
+
+            return cost;
+        }
+
+        public Transaction SellAsset(IIndexedOhlcv indexedCandle, Transaction lastTransaction)
+        {
+            var nextCandle = indexedCandle.Next;
+            decimal quantity = lastTransaction.Quantity;
+            decimal tradeValue = nextCandle.Open * quantity;
+            var fees = DetermineTransactionFee(quantity, tradeValue);
+
+            var costs = RoundingDecimals != -1
+                ? Math.Round(fees, RoundingDecimals)
+                : fees;
+
+            decimal cashWhenSellAsset = nextCandle.Open * quantity - costs;
+
+            cashWhenSellAsset -= costs * cashWhenSellAsset;
+
+            return new Transaction(indexedCandle.BackingList, nextCandle.Index, nextCandle.DateTime, TransactionType.Sell, quantity, cashWhenSellAsset, costs);
+        }
+
+        private decimal DetermineTransactionFee(decimal quantity, decimal tradeValue)
+        {
+            var finraCost = (FINRAFees * quantity);
+
+            if(finraCost > 5.95m)
+                finraCost = 5.95m;
+
+            return (tradeValue * TransactionFees) + finraCost;
+        }
+    }
+}

--- a/Trady.Analysis/Backtest/Transaction.cs
+++ b/Trady.Analysis/Backtest/Transaction.cs
@@ -7,7 +7,7 @@ namespace Trady.Analysis.Backtest
 {
     public class Transaction : IEquatable<Transaction>
     {
-        public Transaction(IEnumerable<IOhlcv> candles, int index, DateTimeOffset dateTime, TransactionType type, decimal quantity, decimal absCashFlow)
+        public Transaction(IEnumerable<IOhlcv> candles, int index, DateTimeOffset dateTime, TransactionType type, decimal quantity, decimal absCashFlow, decimal cost)
         {
             OhlcvList = candles;
             Index = index;
@@ -15,6 +15,7 @@ namespace Trady.Analysis.Backtest
             Type = type;
             Quantity = quantity;
             AbsoluteCashFlow = absCashFlow;
+            Cost = cost;
         }
 
         public IEnumerable<IOhlcv> OhlcvList { get; }
@@ -29,6 +30,8 @@ namespace Trady.Analysis.Backtest
 
         public decimal AbsoluteCashFlow { get; }
 
+        public decimal Cost { get; set; }
+
         public bool Equals(Transaction other)
             => other != null
                && OhlcvList.Equals(other.OhlcvList)
@@ -36,7 +39,8 @@ namespace Trady.Analysis.Backtest
                && Index == other.Index
                && Type == other.Type
                && Quantity == other.Quantity
-               && AbsoluteCashFlow == other.AbsoluteCashFlow;
+               && AbsoluteCashFlow == other.AbsoluteCashFlow
+               && Cost == other.Cost;
 
         public override bool Equals(object obj)
         {
@@ -50,7 +54,7 @@ namespace Trady.Analysis.Backtest
 
         public override string ToString()
         {
-            return $"Idx: {Index}; Date: {DateTime:d} Type: {Type}; Quantity: {Quantity:N3}; AbsoluteCashFlow: {AbsoluteCashFlow:N3}";
+            return $"Idx: {Index}; Date: {DateTime:d} Type: {Type}; Quantity: {Quantity:N3}; AbsoluteCashFlow: {AbsoluteCashFlow:N3}; Cost: {Cost:N3}";
         }
     }
 }

--- a/Trady.Analysis/Extension/IndexedIOhlcvDataExtension.cs
+++ b/Trady.Analysis/Extension/IndexedIOhlcvDataExtension.cs
@@ -38,10 +38,10 @@ namespace Trady.Analysis.Extension
         public static bool IsBelowBbLow(this IIndexedOhlcv ic, int periodCount, int sdCount)
             => ic.Get<BollingerBands>(periodCount, sdCount)[ic.Index].Tick.IsTrue((low, mid, up) => ic.Close < low);
 
-        public static bool IsRsiOverbought(this IIndexedOhlcv ic, int periodCount)
+        public static bool IsRsiOverbought(this IIndexedOhlcv ic, int periodCount = 14)
             => ic.Get<RelativeStrengthIndex>(periodCount)[ic.Index].Tick.IsTrue(t => t >= 70);
 
-        public static bool IsRsiOversold(this IIndexedOhlcv ic, int periodCount)
+        public static bool IsRsiOversold(this IIndexedOhlcv ic, int periodCount = 14)
             => ic.Get<RelativeStrengthIndex>(periodCount)[ic.Index].Tick.IsTrue(t => t <= 30);
 
         public static bool IsFastStoOverbought(this IIndexedOhlcv ic, int periodCount, int smaPeriodCount)
@@ -62,13 +62,13 @@ namespace Trady.Analysis.Extension
         public static bool IsSlowStoOversold(this IIndexedOhlcv ic, int periodCount, int smaPeriodCountD)
             => ic.Get<Stochastics.Slow>(periodCount, smaPeriodCountD)[ic.Index].Tick.IsTrue((k, d, j) => k <= 20);
 
-        public static bool IsAboveSma(this IIndexedOhlcv ic, int periodCount)
+        public static bool IsAboveSma(this IIndexedOhlcv ic, int periodCount = 30)
             => ic.Get<SimpleMovingAverage>(periodCount)[ic.Index].Tick.IsTrue(t => ic.Close > t);
 
         public static bool IsAboveEma(this IIndexedOhlcv ic, int periodCount)
             => ic.Get<ExponentialMovingAverage>(periodCount)[ic.Index].Tick.IsTrue(t => ic.Close > t);
 
-        public static bool IsBelowSma(this IIndexedOhlcv ic, int periodCount)
+        public static bool IsBelowSma(this IIndexedOhlcv ic, int periodCount = 30)
             => ic.Get<SimpleMovingAverage>(periodCount)[ic.Index].Tick.IsTrue(t => ic.Close < t);
 
         public static bool IsBelowEma(this IIndexedOhlcv ic, int periodCount)
@@ -98,10 +98,10 @@ namespace Trady.Analysis.Extension
         public static bool IsEmaOscBearish(this IIndexedOhlcv ic, int periodCount1, int periodCount2)
             => ic.Get<ExponentialMovingAverageOscillator>(periodCount1, periodCount2).Diff(ic.Index).Tick.IsNegative();
 
-        public static bool IsMacdOscBullish(this IIndexedOhlcv ic, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
+        public static bool IsMacdOscBullish(this IIndexedOhlcv ic, int emaPeriodCount1 = 12, int emaPeriodCount2 = 26, int demPeriodCount = 9)
             => ic.Get<MovingAverageConvergenceDivergenceHistogram>(emaPeriodCount1, emaPeriodCount2, demPeriodCount).Diff(ic.Index).Tick.IsPositive();
 
-        public static bool IsMacdOscBearish(this IIndexedOhlcv ic, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
+        public static bool IsMacdOscBearish(this IIndexedOhlcv ic, int emaPeriodCount1 = 12, int emaPeriodCount2 = 26, int demPeriodCount = 9)
             => ic.Get<MovingAverageConvergenceDivergenceHistogram>(emaPeriodCount1, emaPeriodCount2, demPeriodCount).Diff(ic.Index).Tick.IsNegative();
 
         public static bool IsFastStoOscBullish(this IIndexedOhlcv ic, int periodCount, int smaPeriodCount)
@@ -138,11 +138,11 @@ namespace Trady.Analysis.Extension
             => ic.Get<ExponentialMovingAverageOscillator>(periodCount1, periodCount2).ComputeNeighbour(ic.Index)
                  .IsTrue((prev, current, _) => prev.Tick.IsPositive() && current.Tick.IsNegative());
 
-        public static bool IsMacdBullishCross(this IIndexedOhlcv ic, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
+        public static bool IsMacdBullishCross(this IIndexedOhlcv ic, int emaPeriodCount1 = 12, int emaPeriodCount2 = 26, int demPeriodCount = 9)
             => ic.Get<MovingAverageConvergenceDivergenceHistogram>(emaPeriodCount1, emaPeriodCount2, demPeriodCount).ComputeNeighbour(ic.Index)
                  .IsTrue((prev, current, _) => prev.Tick.IsNegative() && current.Tick.IsPositive());
 
-        public static bool IsMacdBearishCross(this IIndexedOhlcv ic, int emaPeriodCount1, int emaPeriodCount2, int demPeriodCount)
+        public static bool IsMacdBearishCross(this IIndexedOhlcv ic, int emaPeriodCount1 = 12, int emaPeriodCount2 = 26, int demPeriodCount = 9)
             => ic.Get<MovingAverageConvergenceDivergenceHistogram>(emaPeriodCount1, emaPeriodCount2, demPeriodCount).ComputeNeighbour(ic.Index)
                  .IsTrue((prev, current, _) => prev.Tick.IsPositive() && current.Tick.IsNegative());
 

--- a/Trady.Analysis/Trady.Analysis.csproj
+++ b/Trady.Analysis/Trady.Analysis.csproj
@@ -51,7 +51,6 @@
   </ItemGroup>
   <!--<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />-->
   <ItemGroup>
-    <Folder Include="Backtest\" />
     <Folder Include="Candlestick\" />
   </ItemGroup>
 </Project>

--- a/Trady.Test/BacktestTest.cs
+++ b/Trady.Test/BacktestTest.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Trady.Analysis;
 using Trady.Analysis.Backtest;
+using Trady.Analysis.Backtest.FeeCalculators;
 using Trady.Analysis.Extension;
 using Trady.Analysis.Indicator;
 using Trady.Core.Infrastructure;
@@ -16,6 +17,7 @@ using Trady.Importer.Csv;
 
 namespace Trady.Test
 {
+    
     [TestClass]
     public class BacktestTest
     {
@@ -56,14 +58,14 @@ namespace Trady.Test
 			var result = runner.RunAsync(10000).Result;
 			var expecteds = new List<Transaction>
 			{
-				new Transaction(candles, 19, new DateTime(2012, 6, 15), TransactionType.Buy, 350, 9979.5m),
-				new Transaction(candles, 40, new DateTime(2012, 7, 17), TransactionType.Sell, 350, 9967m),
-				new Transaction(candles, 62, new DateTime(2012, 8, 16), TransactionType.Buy, 488, 9975.720488m),
-				new Transaction(candles, 99, new DateTime(2012, 10, 9), TransactionType.Sell, 488, 9949.319512m),
-				new Transaction(candles, 111, new DateTime(2012, 10, 25), TransactionType.Buy, 427, 9945.830427m),
-				new Transaction(candles, 120, new DateTime(2012, 11,9), TransactionType.Sell, 427, 8521.919573m),
-				new Transaction(candles, 124, new DateTime(2012, 11, 15), TransactionType.Buy, 382, 8534.88m),
-				new Transaction(candles, 145, new DateTime(2012, 12, 17), TransactionType.Sell, 382, 10225.14m)
+				new Transaction(candles, 19, new DateTime(2012, 6, 15), TransactionType.Buy, 350, 9979.5m, 1),
+				new Transaction(candles, 40, new DateTime(2012, 7, 17), TransactionType.Sell, 350, 9967m, 1),
+				new Transaction(candles, 62, new DateTime(2012, 8, 16), TransactionType.Buy, 488, 9975.720488m, 1),
+				new Transaction(candles, 99, new DateTime(2012, 10, 9), TransactionType.Sell, 488, 9949.319512m, 1),
+				new Transaction(candles, 111, new DateTime(2012, 10, 25), TransactionType.Buy, 427, 9945.830427m, 1),
+				new Transaction(candles, 120, new DateTime(2012, 11,9), TransactionType.Sell, 427, 8521.919573m, 1),
+				new Transaction(candles, 124, new DateTime(2012, 11, 15), TransactionType.Buy, 382, 8534.88m, 1),
+				new Transaction(candles, 145, new DateTime(2012, 12, 17), TransactionType.Sell, 382, 10225.14m, 1)
 			};
             
             CollectionAssert.AreEquivalent(expecteds, result.Transactions.ToList(), $"Actual collection :{Environment.NewLine}{ToString(result.Transactions)}");
@@ -94,14 +96,14 @@ namespace Trady.Test
             var result = runner.RunAsync(10000).Result;
             var expecteds = new List<Transaction>
             {
-                new Transaction(candles, 19, new DateTime(2012, 6, 15), TransactionType.Buy, 350.71904594878989828130480533m, 10000.000000000000000000000000m),
-                new Transaction(candles, 40, new DateTime(2012, 7, 17), TransactionType.Sell, 350.71904594878989828130480533m, 9987.478428621536303051560856m),
-                new Transaction(candles, 62, new DateTime(2012, 8, 16), TransactionType.Buy, 488.57524168523946271096370573m, 9987.478428621536303051560856m),
-                new Transaction(candles, 99, new DateTime(2012, 10, 9), TransactionType.Sell, 488.57524168523946271096370573m, 9961.048689386790959437087249m),
-                new Transaction(candles, 111, new DateTime(2012, 10, 25), TransactionType.Buy, 427.6534247201960600790479678m, 9961.048689386790959437087249m),
-                new Transaction(candles, 120, new DateTime(2012, 11, 9), TransactionType.Sell, 427.6534247201960600790479678m, 8534.961929761688638981737358m),
-                new Transaction(candles, 124, new DateTime(2012, 11, 15), TransactionType.Buy, 382.00366740204514946202942516m, 8534.961929761688638981737358m),
-                new Transaction(candles, 145, new DateTime(2012, 12, 17), TransactionType.Sell, 382.00366740204514946202942516m, 10225.238176352748651098527712m)
+                new Transaction(candles, 19, new DateTime(2012, 6, 15), TransactionType.Buy, 350.71904594878989828130480533m, 10000.000000000000000000000000m, 1),
+                new Transaction(candles, 40, new DateTime(2012, 7, 17), TransactionType.Sell, 350.71904594878989828130480533m, 9987.478428621536303051560856m, 1),
+                new Transaction(candles, 62, new DateTime(2012, 8, 16), TransactionType.Buy, 488.57524168523946271096370573m, 9987.478428621536303051560856m, 1),
+                new Transaction(candles, 99, new DateTime(2012, 10, 9), TransactionType.Sell, 488.57524168523946271096370573m, 9961.048689386790959437087249m, 1),
+                new Transaction(candles, 111, new DateTime(2012, 10, 25), TransactionType.Buy, 427.6534247201960600790479678m, 9961.048689386790959437087249m, 1),
+                new Transaction(candles, 120, new DateTime(2012, 11, 9), TransactionType.Sell, 427.6534247201960600790479678m, 8534.961929761688638981737358m, 1),
+                new Transaction(candles, 124, new DateTime(2012, 11, 15), TransactionType.Buy, 382.00366740204514946202942516m, 8534.961929761688638981737358m, 1),
+                new Transaction(candles, 145, new DateTime(2012, 12, 17), TransactionType.Sell, 382.00366740204514946202942516m, 10225.238176352748651098527712m, 1)
             };
             
             CollectionAssert.AreEquivalent(expecteds, result.Transactions.ToList(), $"Actual collection :{Environment.NewLine}{ToString(result.Transactions)}");
@@ -121,8 +123,8 @@ namespace Trady.Test
 
             var runner = new Builder()
                 .Add(candles)
+                .Calculator(new FeeCalculator(0.001m, 1, 2))
                 .BuyWithAllAvailableCash()
-                .FlatExchangeFeeRate(0.001m)
                 .Buy(buyRule)
                 .Sell(sellRule)
                 .Build();
@@ -133,20 +135,20 @@ namespace Trady.Test
             var result = runner.RunAsync(10000).Result;
             var expecteds = new List<Transaction>
             {
-                new Transaction(candles, 19, new DateTime(2012, 6, 15), TransactionType.Buy, 350.36832690284110838302350052m, 10000.000000000000000000000000m),
-                new Transaction(candles, 40, new DateTime(2012, 7, 17), TransactionType.Sell, 350.36832690284110838302350052m, 9967.512460242721851981760786m),
-                new Transaction(candles, 62, new DateTime(2012, 8, 16), TransactionType.Buy, 487.11083467082409292102182506m, 9967.512460242721851981760786m),
-                new Transaction(candles, 99, new DateTime(2012, 10, 9), TransactionType.Sell, 487.11083467082409292102182506m, 9921.258242395441315251706550m),
-                new Transaction(candles, 111, new DateTime(2012, 10, 25), TransactionType.Buy, 425.51900208819423725814588172m, 9921.258242395441315251706550m),
-                new Transaction(candles, 120, new DateTime(2012, 11, 9), TransactionType.Sell, 425.51900208819423725814588172m, 8483.866497305193532590876186m),
-                new Transaction(candles, 124, new DateTime(2012, 11, 15), TransactionType.Buy, 379.33677846051424973403246687m, 8483.866497305193532590876186m),
-                new Transaction(candles, 145, new DateTime(2012, 12, 17), TransactionType.Sell, 379.33677846051424973403246687m, 10143.691713828578498914669089m)
+                new Transaction(candles, 19, new DateTime(2012, 6, 15), TransactionType.Buy, 350.36832690284110838302350052m, 10000.000000000000000000000000m, 1.35m),
+                new Transaction(candles, 40, new DateTime(2012, 7, 17), TransactionType.Sell, 350.36832690284110838302350052m, 9967.512460242721851981760786m, 10.98m),
+                new Transaction(candles, 62, new DateTime(2012, 8, 16), TransactionType.Buy, 487.11083467082409292102182506m, 9967.512460242721851981760786m, 1.49m),
+                new Transaction(candles, 99, new DateTime(2012, 10, 9), TransactionType.Sell, 487.11083467082409292102182506m, 9921.258242395441315251706550m, 10.93m),
+                new Transaction(candles, 111, new DateTime(2012, 10, 25), TransactionType.Buy, 425.51900208819423725814588172m, 9921.258242395441315251706550m, 1.43m),
+                new Transaction(candles, 120, new DateTime(2012, 11, 9), TransactionType.Sell, 425.51900208819423725814588172m, 8483.866497305193532590876186m, 9.49m),
+                new Transaction(candles, 124, new DateTime(2012, 11, 15), TransactionType.Buy, 379.33677846051424973403246687m, 8483.866497305193532590876186m, 1.38m),
+                new Transaction(candles, 145, new DateTime(2012, 12, 17), TransactionType.Sell, 379.33677846051424973403246687m, 10143.691713828578498914669089m, 11.15m)
             };
             
             CollectionAssert.AreEquivalent(expecteds, result.Transactions.ToList(), $"Actual collection :{Environment.NewLine}{ToString(result.Transactions)}");
             Assert.AreEqual(10000m, result.TotalPrincipal);
             Assert.AreEqual(10143.691713828578498914669089m, result.TotalCorrectedBalance);
-            Assert.AreEqual(0.0143691713828578498914669089m, result.TotalCorrectedProfitLossRatio);
+            Assert.AreEqual(0.0143691713828578498914669089m, result.TotalCorrectedProfitLossRatio);            
         }
 
         private string ToString(IEnumerable<Transaction> resultTransactions)
@@ -195,13 +197,13 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestIssue70()
         {
-            var importer = new AlphaVantageImporter("[YourAPIKey]", OutputSize.full);
+            var importer = new AlphaVantageImporter("WUT9R5SC4IHCNA4S", OutputSize.full);
             var fb = importer.ImportAsync("fb", startTime: new DateTime(2018, 1, 1), period: PeriodOption.PerMinute).Result;
 
-            var importer2 = new AlphaVantageImporter("[YourAPIKey]", OutputSize.full);
+            var importer2 = new AlphaVantageImporter("WUT9R5SC4IHCNA4S", OutputSize.full);
             var wba = importer2.ImportAsync("xom", startTime: new DateTime(2018, 1, 1), period: PeriodOption.PerMinute).Result;
 
-            var importer3 = new AlphaVantageImporter("[YourAPIKey]", OutputSize.full);
+            var importer3 = new AlphaVantageImporter("WUT9R5SC4IHCNA4S", OutputSize.full);
             var att = importer3.ImportAsync("t", startTime: new DateTime(2018, 1, 1), period: PeriodOption.PerMinute).Result;
 
             var buyRule = Rule.Create(c => c.IsMacdBullishCross(12, 26, 9))
@@ -211,12 +213,12 @@ namespace Trady.Test
                             .And(c => c.IsRsiOverbought2());
 
             var runner = new Trady.Analysis.Backtest.Builder()
-                //.Add(att, 33).Add(wba, 33).Add(fb, 33)
-                .Add(wba)
+                .Add(att, 33).Add(wba, 33).Add(fb, 33)
+                //.Add(wba)
                 .Buy(buyRule)
                 .Sell(sellRule)
-                .FlatExchangeFeeRate(5)
-                .Premium(1)
+                //.FlatExchangeFeeRate(.05m)
+                .Premium(5)
                 .Build();
 
             var result = runner.RunAsync(10000, new DateTime(2018, 1, 1)).Result;


### PR DESCRIPTION
@lppkarl 

==Breaking Change!==
I've refactored the runner a bit to allow anyone to add their own cost structure for any brokerage.  I call this FeeCalculators.  They are in their own namespace. I've put the default one in (FeeCalculator) which defaults to what was there originally.  I've also added an InteractiveBrokersFeeCalculator which models their fee structure.  This can be used as an example.

I put this in mainly because I saw that most brokerage firm fees were involved and very different per brokerage firm.  And costs to me were something that should have more insight.

I've also exposed the cost within the Transaction object.

This also has some minor changes where I added some default values for some common indicators.  I thought this might be a good practice to get into to make the library easier to consume.

This change should require another major version number increase to avoid issues with consumers.  I was not able to keep the contract the same.  The Premium & ExchangeFee components were so baked into the builder/runner.  Now it's using SOLID principles and those bits are now have separation of concerns.  See the backtests with fees as an example.