### PR TITLE
Resolves #70

### DIFF
--- a/Trady.Analysis/Backtest/FeeCalculators/FeeCalculator.cs
+++ b/Trady.Analysis/Backtest/FeeCalculators/FeeCalculator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Serialization;
 using Trady.Core.Infrastructure;
 
 namespace Trady.Analysis.Backtest.FeeCalculators
@@ -32,6 +33,8 @@ namespace Trady.Analysis.Backtest.FeeCalculators
 
         public Transaction BuyAsset(IIndexedOhlcv indexedCandle, decimal cash, IIndexedOhlcv nextCandle, bool buyInCompleteQuantities)
         {
+            ValidateProperties();
+
             decimal quantity = (cash - Premium) / nextCandle.Open;
             if(buyInCompleteQuantities)
                 quantity = Math.Floor(quantity);
@@ -54,7 +57,9 @@ namespace Trady.Analysis.Backtest.FeeCalculators
        
 
         public Transaction SellAsset(IIndexedOhlcv indexedCandle, Transaction lastTransaction)
-        {            
+        {
+            ValidateProperties();
+
             var nextCandle = indexedCandle.Next;
             
             decimal quantity = lastTransaction.Quantity;
@@ -71,5 +76,21 @@ namespace Trady.Analysis.Backtest.FeeCalculators
 
             return new Transaction(indexedCandle.BackingList, nextCandle.Index, nextCandle.DateTime, TransactionType.Sell, quantity, cashWhenSellAsset, costs);
         }
+
+        private void ValidateProperties()
+        {
+            if(FlatExchangeFee < 0 || FlatExchangeFee >= 1)
+            {
+                throw new FeeCalculationException("The FlatExchangeFee must be set to a value that is greater than equal to zero (>= 0) and less than one (< 1).  Example => .25");
+            }
+        }
+    }
+
+    public class FeeCalculationException : Exception
+    {
+        public FeeCalculationException() : base() { }
+        public FeeCalculationException(string message) : base(message) { }
+        public FeeCalculationException(string message, Exception innerException) : base(message, innerException) { }
+        public FeeCalculationException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/Trady.Test/BacktestTest.cs
+++ b/Trady.Test/BacktestTest.cs
@@ -197,14 +197,14 @@ namespace Trady.Test
         [TestMethod]
         public async Task TestIssue70()
         {
-            var importer = new AlphaVantageImporter("WUT9R5SC4IHCNA4S", OutputSize.full);
-            var fb = importer.ImportAsync("fb", startTime: new DateTime(2018, 1, 1), period: PeriodOption.PerMinute).Result;
+            //var importer = new AlphaVantageImporter("WUT9R5SC4IHCNA4S", OutputSize.full);
+            //var fb = importer.ImportAsync("fb", startTime: new DateTime(2018, 1, 1), period: PeriodOption.PerMinute).Result;
 
             var importer2 = new AlphaVantageImporter("WUT9R5SC4IHCNA4S", OutputSize.full);
             var wba = importer2.ImportAsync("xom", startTime: new DateTime(2018, 1, 1), period: PeriodOption.PerMinute).Result;
 
-            var importer3 = new AlphaVantageImporter("WUT9R5SC4IHCNA4S", OutputSize.full);
-            var att = importer3.ImportAsync("t", startTime: new DateTime(2018, 1, 1), period: PeriodOption.PerMinute).Result;
+            //var importer3 = new AlphaVantageImporter("WUT9R5SC4IHCNA4S", OutputSize.full);
+            //var att = importer3.ImportAsync("t", startTime: new DateTime(2018, 1, 1), period: PeriodOption.PerMinute).Result;
 
             var buyRule = Rule.Create(c => c.IsMacdBullishCross(12, 26, 9))
                             .And(c => c.IsRsiOversold2());
@@ -213,18 +213,22 @@ namespace Trady.Test
                             .And(c => c.IsRsiOverbought2());
 
             var runner = new Trady.Analysis.Backtest.Builder()
-                .Add(att, 33).Add(wba, 33).Add(fb, 33)
-                //.Add(wba)
+                //.Add(att, 33).Add(wba, 33).Add(fb, 33)
+                .Add(wba)
                 .Buy(buyRule)
                 .Sell(sellRule)
                 //.FlatExchangeFeeRate(.05m)
-                .Premium(5)
+                .FlatExchangeFeeRate(5)
+                //.Premium(5)
                 .Build();
 
-            var result = runner.RunAsync(10000, new DateTime(2018, 1, 1)).Result;
+            Assert.ThrowsException<AggregateException>(() => runner.RunAsync(10000, new DateTime(2018, 1, 1)).Result, "The FlatExchangeFee must be set to a value that is greater than equal to zero(>= 0) and less than one(< 1).Example => .25");
+            //var result = runner.RunAsync(10000, new DateTime(2018, 1, 1)).Result;
 
-            Console.WriteLine($"Transaction count: {result.Transactions.Count():#.##}, P/L ratio: {result.TotalCorrectedProfitLossRatio * 100}%, Principal: {result.TotalPrincipal}, Total: {result.TotalCorrectedBalance}");
+            //Console.WriteLine($"Transaction count: {result.Transactions.Count():#.##}, P/L ratio: {result.TotalCorrectedProfitLossRatio * 100}%, Principal: {result.TotalPrincipal}, Total: {result.TotalCorrectedBalance}");
         }
+
+        
     }
 
     public static class Signals


### PR DESCRIPTION
This commit ensures the FlatExchangeFeeRates are validated.  They must be a number >= 0 and < 1.  Otherwise, it's an invalid number that causes bad calculations downstream.  If invalid, the system will throw an exception in the first attempt to calculate.

I've created a new exception class for this called FeeCalculationException so that its crystal clear what the root cause is.

@lppkarl If you are okay with this change, can you please merge the pull request?