### PR TITLE
fixes IOhclv IsBull, IsBear recognition, also added IsDoji extension

### DIFF
--- a/Trady.Core/CandleExtension.cs
+++ b/Trady.Core/CandleExtension.cs
@@ -15,9 +15,10 @@ namespace Trady.Core
 
         public static decimal GetBody(this IOhlcv candle) => Math.Abs(candle.Open - candle.Close);
 
-        public static bool IsBull(this IOhlcv candle) => candle.Open - candle.Close > 0;
+        public static bool IsBull(this IOhlcv candle) => candle.Open < candle.Close;
+        public static bool IsBear(this IOhlcv candle) => candle.Open > candle.Close;
+        public static bool IsDoji(this IOhlcv candle) => candle.Open == candle.Close;
 
-        public static bool IsBear(this IOhlcv candle) => candle.Open - candle.Close < 0;
 
         #region candle list transformation
 


### PR DESCRIPTION
Hello. According to investopedia, here was two mistakes with IsBull and IsBear candlestick recognition
Bull candlestick must have Close greater than Open and Bear candlestick - Open greater than Close. Doji candlestick must have Open equals to Close