### PR TITLE
Update CsvHelper

### DIFF
--- a/Trady.Importer.AlphaVantage/AlphaVantageImporter.cs
+++ b/Trady.Importer.AlphaVantage/AlphaVantageImporter.cs
@@ -94,7 +94,7 @@ namespace Trady.Importer.AlphaVantage
             var culture = "en-US";
             var cultureInfo = new CultureInfo(culture);
             var candles = new List<IOhlcv>();
-            using(var csvReader = new CsvReader(textReader, new Configuration() { CultureInfo = cultureInfo, Delimiter = ",", HasHeaderRecord = true }))
+            using(var csvReader = new CsvReader(textReader, new CsvConfiguration(cultureInfo) { Delimiter = ",", HasHeaderRecord = true }))
             {
                 bool isHeaderBypassed = false;
                 while (csvReader.Read())

--- a/Trady.Importer.AlphaVantage/Trady.Importer.AlphaVantage.csproj
+++ b/Trady.Importer.AlphaVantage/Trady.Importer.AlphaVantage.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="7.1.1" />
+    <PackageReference Include="CsvHelper" Version="13.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Trady.Importer.Csv/CsvImporter.cs
+++ b/Trady.Importer.Csv/CsvImporter.cs
@@ -45,7 +45,7 @@ namespace Trady.Importer.Csv
             {
                 using (var fs = File.OpenRead(_path))
                 using (var sr = new StreamReader(fs))
-                using (var csvReader = new CsvReader(sr, new Configuration() { CultureInfo = _culture, Delimiter = string.IsNullOrWhiteSpace(_delimiter) ? "," : _delimiter, HasHeaderRecord = _hasHeader }))
+                using (var csvReader = new CsvReader(sr, new CsvConfiguration(_culture) { Delimiter = string.IsNullOrWhiteSpace(_delimiter) ? "," : _delimiter, HasHeaderRecord = _hasHeader }))
                 {
                     var candles = new List<IOhlcv>();
                     bool isHeaderBypassed = false;

--- a/Trady.Importer.Csv/Trady.Importer.Csv.csproj
+++ b/Trady.Importer.Csv/Trady.Importer.Csv.csproj
@@ -34,7 +34,7 @@
       <LangVersion>latest</LangVersion>
     </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="7.1.1" />
+    <PackageReference Include="CsvHelper" Version="13.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Trady.Core\Trady.Core.csproj" />


### PR DESCRIPTION
Updates CsvHelper to resolve CsvHelper constructor breaking change introduced into version 13.0.0; Resolves #116

This should change should help users who use this library AND CsvHelper to use CsvHelpers newer packages and features, such as async enumerable support